### PR TITLE
v1.6.1-1.5.1

### DIFF
--- a/common/src/main/kotlin/us/timinc/mc/cobblemon/timcore/config/OverridableOption.kt
+++ b/common/src/main/kotlin/us/timinc/mc/cobblemon/timcore/config/OverridableOption.kt
@@ -7,7 +7,7 @@ abstract class OverridableOption<ValueType, ContextType>(
     open val value: ValueType,
     open val overrides: Map<String, ValueType> = emptyMap(),
 ) {
-    data class PokemonOption<ValueType>(override val value: ValueType, override val overrides: Map<String, ValueType>) :
+    data class PokemonOption<ValueType>(override val value: ValueType, override val overrides: Map<String, ValueType> = emptyMap()) :
         OverridableOption<ValueType, Pokemon>(value, overrides) {
         override fun getValue(context: Pokemon): ValueType =
             overrides.entries.find { (k) -> PokemonProperties.parse(k).matches(context) }?.value ?: value

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ org.gradle.configureondemand=true
 
 modId=tim_core
 modCobblemonVersion=1.6.1
-modMyVersion=1.5.0
+modMyVersion=1.5.1
 modName=Tim Core
 modDescription=What if my Cobblemon mods worked without a bunch of copy/pasting?
 modAuthor=timinc aka Timothy Metcalfe


### PR DESCRIPTION
* Fix overridable Pokémon option requiring an overrides by providing a default empty map.