### PR TITLE
v1.6.1-1.6.0

### DIFF
--- a/common/src/main/kotlin/us/timinc/mc/cobblemon/timcore/PokemonExtensions.kt
+++ b/common/src/main/kotlin/us/timinc/mc/cobblemon/timcore/PokemonExtensions.kt
@@ -4,3 +4,4 @@ import com.cobblemon.mod.common.pokemon.Pokemon
 
 fun Pokemon.getIdentifier() = "${getDisplayName().string}[${uuid}]"
 fun Pokemon.getBucket() = this.persistentData.getStringOrNull(TimCore.DataKeys.SPAWNED_IN_BUCKET)
+fun Pokemon.immuneToQuickBall() = this.persistentData.contains(TimCore.DataKeys.ALREADY_HIT_WITH_QUICK_BALL)

--- a/common/src/main/kotlin/us/timinc/mc/cobblemon/timcore/PokemonMatcher.kt
+++ b/common/src/main/kotlin/us/timinc/mc/cobblemon/timcore/PokemonMatcher.kt
@@ -2,6 +2,8 @@ package us.timinc.mc.cobblemon.timcore
 
 import com.cobblemon.mod.common.api.pokemon.PokemonProperties
 import com.cobblemon.mod.common.pokemon.Pokemon
+import com.mojang.serialization.Codec
+import com.mojang.serialization.codecs.RecordCodecBuilder
 import us.timinc.mc.cobblemon.timcore.TimCore.debugger
 
 data class PokemonMatcher(
@@ -13,6 +15,21 @@ data class PokemonMatcher(
     val buckets: List<String> = emptyList(),
     val matchOne: Boolean = false,
 ) {
+    companion object {
+        val CODEC: Codec<PokemonMatcher> = RecordCodecBuilder.create { instance ->
+            instance.group(
+                Codec.STRING.optionalFieldOf("properties", "").forGetter { it.properties },
+                Codec.STRING.listOf().optionalFieldOf("labels", emptyList()).forGetter { it.labels },
+                Codec.BOOL.optionalFieldOf("anyLabel", false).forGetter { it.anyLabel },
+                Codec.unboundedMap(Codec.STRING, Codec.STRING).optionalFieldOf("persistentData", emptyMap())
+                    .forGetter { it.persistentData },
+                Codec.BOOL.optionalFieldOf("anyPersistentData", false).forGetter { it.anyPersistentData },
+                Codec.STRING.listOf().optionalFieldOf("buckets", emptyList()).forGetter { it.buckets },
+                Codec.BOOL.optionalFieldOf("matchOne", false).forGetter { it.matchOne }
+            ).apply(instance, ::PokemonMatcher)
+        }
+    }
+
     @delegate:Transient
     private val parsedProps by lazy {
         properties.takeIf { it.isNotBlank() }?.let(PokemonProperties::parse)

--- a/common/src/main/kotlin/us/timinc/mc/cobblemon/timcore/TimCore.kt
+++ b/common/src/main/kotlin/us/timinc/mc/cobblemon/timcore/TimCore.kt
@@ -7,6 +7,7 @@ import net.minecraft.tags.TagKey
 import net.minecraft.world.item.Item
 import us.timinc.mc.cobblemon.timcore.handler.AttachBucket
 import us.timinc.mc.cobblemon.timcore.handler.ExpAllHandler
+import us.timinc.mc.cobblemon.timcore.handler.PreventQuickBallSpam
 
 const val MOD_ID = "tim_core"
 
@@ -16,6 +17,7 @@ object TimCore : AbstractMod<TimCore.Config>(MOD_ID, Config::class.java) {
         val enableExpAll: Boolean = true
         val forceExpAll: Boolean = false
         val addBucketToData: Boolean = true
+        val preventQuickBallSpam: Boolean = true
     }
 
     object Tags {
@@ -25,10 +27,12 @@ object TimCore : AbstractMod<TimCore.Config>(MOD_ID, Config::class.java) {
 
     object DataKeys {
         const val SPAWNED_IN_BUCKET = "tim_core:spawned_in_bucket"
+        const val ALREADY_HIT_WITH_QUICK_BALL = "tim_core:already_hit_with_quick_ball"
     }
 
     init {
         CobblemonEvents.BATTLE_VICTORY.subscribe(Priority.HIGHEST, ExpAllHandler::handle)
         CobblemonEvents.POKEMON_ENTITY_SPAWN.subscribe(Priority.HIGHEST, AttachBucket::handle)
+        CobblemonEvents.POKEMON_CATCH_RATE.subscribe(Priority.LOWEST, PreventQuickBallSpam::handle)
     }
 }

--- a/common/src/main/kotlin/us/timinc/mc/cobblemon/timcore/handler/PreventQuickBallSpam.kt
+++ b/common/src/main/kotlin/us/timinc/mc/cobblemon/timcore/handler/PreventQuickBallSpam.kt
@@ -1,0 +1,24 @@
+package us.timinc.mc.cobblemon.timcore.handler
+
+import com.cobblemon.mod.common.api.events.pokeball.PokemonCatchRateEvent
+import com.cobblemon.mod.common.api.pokeball.PokeBalls
+import us.timinc.mc.cobblemon.timcore.AbstractHandler
+import us.timinc.mc.cobblemon.timcore.TimCore.DataKeys.ALREADY_HIT_WITH_QUICK_BALL
+import us.timinc.mc.cobblemon.timcore.TimCore.config
+import us.timinc.mc.cobblemon.timcore.immuneToQuickBall
+
+object PreventQuickBallSpam : AbstractHandler<PokemonCatchRateEvent>() {
+    override fun handle(evt: PokemonCatchRateEvent) {
+        if (!config.preventQuickBallSpam) return
+
+        val pokeball = evt.pokeBallEntity.pokeBall
+        if (pokeball != PokeBalls.QUICK_BALL) return
+
+        val pokemon = evt.pokemonEntity.pokemon
+        if (pokemon.immuneToQuickBall()) {
+            evt.catchRate /= PokeBalls.QUICK_BALL.catchRateModifier.modifyCatchRate(1.0F, evt.thrower, pokemon)
+        } else {
+            pokemon.persistentData.putBoolean(ALREADY_HIT_WITH_QUICK_BALL, true)
+        }
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ org.gradle.configureondemand=true
 
 modId=tim_core
 modCobblemonVersion=1.6.1
-modMyVersion=1.5.3
+modMyVersion=1.6.0
 modName=Tim Core
 modDescription=What if my Cobblemon mods worked without a bunch of copy/pasting?
 modAuthor=timinc aka Timothy Metcalfe


### PR DESCRIPTION
* Added optional logic to prevent Quick Ball spam. If the Pokémon was already hit with a Quick Ball, the catch rate will be divided by the bonus a Quick Ball gives, cancelling out the bonus.
* Added a codec to PokemonMatcher.