### PR TITLE
v1.6.1-1.14.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,10 @@ v1.6.1-1.14
 
 - [Cobblemon](https://www.notion.so/Cobblemon-22157e0d4afd80a49896c70a775a3c7f?pvs=21)
 
+## Known Issues
+
+- v1.6.1-1.14.0 had an issue with properly maximizing a `PokemonRepresentation`'s IVs if the IVs weren’t null, but were empty. v1.6.1-1.14.1 remedied that.
+
 ## Roadmap
 
 If you’d like to keep up with the work being done on the mod, please join [the Discord](https://discord.com/invite/WKAR27SdSv) and subscribe to notifications on the channel for this content. You can also keep track of the to do list available on [the mod’s main page](https://www.notion.so/Tim-Core-22057e0d4afd809b9c02e78f26805376?pvs=21).

--- a/common/src/main/kotlin/us/timinc/mc/cobblemon/timcore/PokemonRepresentation.kt
+++ b/common/src/main/kotlin/us/timinc/mc/cobblemon/timcore/PokemonRepresentation.kt
@@ -67,15 +67,15 @@ abstract class PokemonRepresentation<T>(val pokemon: T) {
 
         override fun makePerfectIvs(count: Int): Set<Stat> {
             val ivs = pokemon.ivs
-            val imperfects = pokemon.ivs?.filter { (_, value) -> value != IVs.MAX_VALUE }?.shuffled()?.take(count)
-            if (imperfects == null) {
+            if (ivs == null || ivs.toList().isEmpty()) {
                 pokemon.ivs = IVs.createRandomIVs(count)
-                return pokemon.ivs!!.filter { (_, value) -> value == IVs.MAX_VALUE }.take(count).map { (stat) -> stat }
+                return ivs!!.filter { (_, value) -> value == IVs.MAX_VALUE }.take(count).map { (stat) -> stat }
                     .toSet()
             }
 
+            val imperfects = ivs.filter { (_, value) -> value != IVs.MAX_VALUE }.shuffled().take(count)
             for ((stat) in imperfects) {
-                ivs!![stat] = IVs.MAX_VALUE
+                ivs[stat] = IVs.MAX_VALUE
             }
             return imperfects.map { (stat) -> stat }.toSet()
         }

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ org.gradle.configureondemand=true
 
 modId=tim_core
 modCobblemonVersion=1.6.1
-modMyVersion=1.14.0
+modMyVersion=1.14.1
 modName=Tim Core
 modDescription=What if my Cobblemon mods worked without a bunch of copy/pasting?
 modAuthor=timinc aka Timothy Metcalfe


### PR DESCRIPTION
* Fixed PokemonRepresentation not dealing with non-null, empty IVs when maximizing IVs.