### PR TITLE
* Added option requiring player have Pokémon in their party in order to fish up a Pokémon.

### DIFF
--- a/common/src/main/kotlin/us/timinc/mc/cobblemon/timcore/TimCore.kt
+++ b/common/src/main/kotlin/us/timinc/mc/cobblemon/timcore/TimCore.kt
@@ -13,6 +13,7 @@ import net.minecraft.network.chat.MutableComponent
 import net.minecraft.tags.TagKey
 import net.minecraft.world.item.Item
 import us.timinc.mc.cobblemon.timcore.handler.*
+import us.timinc.mc.cobblemon.timcore.influence.EntityDidSpawn
 import us.timinc.mc.cobblemon.timcore.influence.PreventSpawnsInfluence
 import java.util.*
 
@@ -30,6 +31,7 @@ object TimCore : AbstractMod<TimCore.Config>(MOD_ID, Config::class.java) {
         val spawnWhitelist: List<String> = emptyList()
         val pokemonEntitiesAreInvulnerable: Boolean = false
         val reservedPokemonEntitiesAreInvulnerable: Boolean = true
+        val requirePartyToFishPokemon: Boolean = false
 
         var _spawnBlacklistMatcher: Set<PokemonMatcher>? = null
         val spawnBlacklistMatcher: Set<PokemonMatcher>
@@ -88,13 +90,18 @@ object TimCore : AbstractMod<TimCore.Config>(MOD_ID, Config::class.java) {
 
     init {
         CobblemonEvents.BATTLE_VICTORY.subscribe(Priority.HIGHEST, ExpAllHandler::handle)
-        CobblemonEvents.POKEMON_ENTITY_SPAWN.subscribe(Priority.HIGHEST, AttachBucket::handle)
-        CobblemonEvents.POKEMON_ENTITY_SPAWN.subscribe(Priority.LOWEST, AttachSpawnCause::handle)
         CobblemonEvents.POKEMON_CATCH_RATE.subscribe(Priority.LOWEST, PreventQuickBallSpam::handle)
         CobblemonEvents.THROWN_POKEBALL_HIT.subscribe(Priority.NORMAL, PokeballHitReserved::handle)
+        CobblemonEvents.POKEMON_ENTITY_SPAWN.subscribe(Priority.HIGHEST, FishingWithoutATeamCanceller::handle)
+        TimCoreEvents.POKEMON_ENTITY_DID_SPAWN.subscribe(Priority.HIGHEST, AttachBucket::handle)
+        TimCoreEvents.POKEMON_ENTITY_DID_SPAWN.subscribe(Priority.HIGHEST, AttachSpawnCause::handle)
 
         PlayerSpawnerFactory.influenceBuilders.add { PreventSpawnsInfluence() }
-        PlatformEvents.SERVER_STARTED.subscribe(Priority.LOWEST) { fishingSpawner.influences.add(PreventSpawnsInfluence()) }
+        PlayerSpawnerFactory.influenceBuilders.add { EntityDidSpawn() }
+        PlatformEvents.SERVER_STARTED.subscribe(Priority.LOWEST) {
+            fishingSpawner.influences.add(PreventSpawnsInfluence())
+            fishingSpawner.influences.add(EntityDidSpawn())
+        }
         TimCore.RELOAD_CONFIG.subscribe {
             config._spawnBlacklistMatcher = null
             config._spawnWhitelistMatcher = null

--- a/common/src/main/kotlin/us/timinc/mc/cobblemon/timcore/TimCoreEvents.kt
+++ b/common/src/main/kotlin/us/timinc/mc/cobblemon/timcore/TimCoreEvents.kt
@@ -3,10 +3,14 @@ package us.timinc.mc.cobblemon.timcore
 import com.cobblemon.mod.common.api.events.CobblemonEvents.BATTLE_FAINTED
 import com.cobblemon.mod.common.api.events.CobblemonEvents.POKEMON_CAPTURED
 import com.cobblemon.mod.common.api.events.CobblemonEvents.POKEMON_FAINTED
+import com.cobblemon.mod.common.api.events.entity.SpawnEvent
 import com.cobblemon.mod.common.api.reactive.EventObservable
 import com.cobblemon.mod.common.api.reactive.Observable.Companion.filter
+import com.cobblemon.mod.common.api.reactive.Observable.Companion.map
+import com.cobblemon.mod.common.entity.pokemon.PokemonEntity
 import com.cobblemon.mod.common.util.isInBattle
 import us.timinc.mc.cobblemon.timcore.event.CheckExpAllEvent
+import us.timinc.mc.cobblemon.timcore.event.EntityDidSpawnEvent
 import us.timinc.mc.cobblemon.timcore.event.PokemonEntityTickedEvent
 
 object TimCoreEvents {
@@ -60,5 +64,18 @@ object TimCoreEvents {
     val WILD_POKEMON_TICKED = POKEMON_TICKED
         .pipe(
             filter { it.entity.pokemon.isWild() }
+        )
+
+    @JvmField
+    val ENTITY_DID_SPAWN = EventObservable<EntityDidSpawnEvent<*>>()
+
+    @JvmField
+    val POKEMON_ENTITY_DID_SPAWN = ENTITY_DID_SPAWN
+        .pipe(
+            filter { it.entity is PokemonEntity },
+            map {
+                @Suppress("UNCHECKED_CAST")
+                it as EntityDidSpawnEvent<PokemonEntity>
+            }
         )
 }

--- a/common/src/main/kotlin/us/timinc/mc/cobblemon/timcore/event/EntityDidSpawnEvent.kt
+++ b/common/src/main/kotlin/us/timinc/mc/cobblemon/timcore/event/EntityDidSpawnEvent.kt
@@ -1,0 +1,9 @@
+package us.timinc.mc.cobblemon.timcore.event
+
+import com.cobblemon.mod.common.api.spawning.context.SpawningContext
+import net.minecraft.world.entity.Entity
+
+data class EntityDidSpawnEvent<T : Entity>(
+    val entity: T,
+    val ctx: SpawningContext
+)

--- a/common/src/main/kotlin/us/timinc/mc/cobblemon/timcore/handler/AttachBucket.kt
+++ b/common/src/main/kotlin/us/timinc/mc/cobblemon/timcore/handler/AttachBucket.kt
@@ -1,13 +1,13 @@
 package us.timinc.mc.cobblemon.timcore.handler
 
-import com.cobblemon.mod.common.api.events.entity.SpawnEvent
 import com.cobblemon.mod.common.entity.pokemon.PokemonEntity
 import us.timinc.mc.cobblemon.timcore.AbstractHandler
 import us.timinc.mc.cobblemon.timcore.TimCore.DataKeys.SPAWNED_IN_BUCKET
 import us.timinc.mc.cobblemon.timcore.TimCore.config
+import us.timinc.mc.cobblemon.timcore.event.EntityDidSpawnEvent
 
-object AttachBucket : AbstractHandler<SpawnEvent<PokemonEntity>>() {
-    override fun handle(evt: SpawnEvent<PokemonEntity>) {
+object AttachBucket : AbstractHandler<EntityDidSpawnEvent<PokemonEntity>>() {
+    override fun handle(evt: EntityDidSpawnEvent<PokemonEntity>) {
         if (!config.addBucketToData) return
         evt.entity.pokemon.persistentData.putString(SPAWNED_IN_BUCKET, evt.ctx.cause.bucket.name)
     }

--- a/common/src/main/kotlin/us/timinc/mc/cobblemon/timcore/handler/AttachSpawnCause.kt
+++ b/common/src/main/kotlin/us/timinc/mc/cobblemon/timcore/handler/AttachSpawnCause.kt
@@ -1,14 +1,14 @@
 package us.timinc.mc.cobblemon.timcore.handler
 
-import com.cobblemon.mod.common.api.events.entity.SpawnEvent
 import com.cobblemon.mod.common.api.spawning.fishing.FishingSpawner
 import com.cobblemon.mod.common.api.spawning.spawner.PlayerSpawner
 import com.cobblemon.mod.common.entity.pokemon.PokemonEntity
 import us.timinc.mc.cobblemon.timcore.AbstractHandler
 import us.timinc.mc.cobblemon.timcore.TimCore
+import us.timinc.mc.cobblemon.timcore.event.EntityDidSpawnEvent
 
-object AttachSpawnCause : AbstractHandler<SpawnEvent<PokemonEntity>>() {
-    override fun handle(evt: SpawnEvent<PokemonEntity>) {
+object AttachSpawnCause : AbstractHandler<EntityDidSpawnEvent<PokemonEntity>>() {
+    override fun handle(evt: EntityDidSpawnEvent<PokemonEntity>) {
         if (!TimCore.config.addSpawnCauseToData) return
 
         val spawner = evt.ctx.cause.spawner

--- a/common/src/main/kotlin/us/timinc/mc/cobblemon/timcore/handler/FishingWithoutATeamCanceller.kt
+++ b/common/src/main/kotlin/us/timinc/mc/cobblemon/timcore/handler/FishingWithoutATeamCanceller.kt
@@ -1,0 +1,25 @@
+package us.timinc.mc.cobblemon.timcore.handler
+
+import com.cobblemon.mod.common.api.events.entity.SpawnEvent
+import com.cobblemon.mod.common.api.spawning.context.FishingSpawningContext
+import com.cobblemon.mod.common.entity.pokemon.PokemonEntity
+import com.cobblemon.mod.common.util.party
+import net.minecraft.server.level.ServerPlayer
+import us.timinc.mc.cobblemon.timcore.AbstractHandler
+import us.timinc.mc.cobblemon.timcore.TimCore
+
+object FishingWithoutATeamCanceller : AbstractHandler<SpawnEvent<PokemonEntity>>() {
+    override fun handle(evt: SpawnEvent<PokemonEntity>) {
+        val ctx = evt.ctx as? FishingSpawningContext ?: return
+        if (TimCore.config.requirePartyToFishPokemon) {
+            val player = ctx.cause.entity as? ServerPlayer
+            if (player != null && player.party().all {
+                    // The Pokémon in the slot can be null. This is silly that it doesn't know that.
+                    @Suppress("SENSELESS_COMPARISON")
+                    it == null
+                }) {
+                evt.cancel()
+            }
+        }
+    }
+}

--- a/common/src/main/kotlin/us/timinc/mc/cobblemon/timcore/influence/EntityDidSpawn.kt
+++ b/common/src/main/kotlin/us/timinc/mc/cobblemon/timcore/influence/EntityDidSpawn.kt
@@ -1,0 +1,14 @@
+package us.timinc.mc.cobblemon.timcore.influence
+
+import com.cobblemon.mod.common.api.spawning.detail.SingleEntitySpawnAction
+import com.cobblemon.mod.common.api.spawning.detail.SpawnAction
+import com.cobblemon.mod.common.api.spawning.influence.SpawningInfluence
+import us.timinc.mc.cobblemon.timcore.TimCoreEvents
+import us.timinc.mc.cobblemon.timcore.event.EntityDidSpawnEvent
+
+class EntityDidSpawn : SpawningInfluence {
+    override fun affectAction(action: SpawnAction<*>) {
+        if (action !is SingleEntitySpawnAction<*>) return
+        action.entity.subscribe { TimCoreEvents.ENTITY_DID_SPAWN.emit(EntityDidSpawnEvent(it, action.ctx)) }
+    }
+}


### PR DESCRIPTION
* Added ENTITY_DID_SPAWN and POKEMON_ENTITY_DID_SPAWN events.
* Migrated bucket and spawn cause attachers to POKEMON_ENTITY_DID_SPAWN.