### PR TITLE
v1.7.0-1.25.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Tim Core
 
-v1.7.0-1.24.1
+v1.7.0-1.25.0
 
 This documentation is out of date, I'm doing rapid development whilst working on 1.7 porting. I'll come back around at some point.
 

--- a/common/src/main/kotlin/us/timinc/mc/cobblemon/timcore/PokemonExtensions.kt
+++ b/common/src/main/kotlin/us/timinc/mc/cobblemon/timcore/PokemonExtensions.kt
@@ -1,6 +1,7 @@
 package us.timinc.mc.cobblemon.timcore
 
 import com.cobblemon.mod.common.pokemon.Pokemon
+import net.minecraft.network.chat.Component
 import net.minecraft.server.level.ServerPlayer
 import us.timinc.mc.cobblemon.timcore.TimCore.debugger
 import java.util.*
@@ -18,6 +19,9 @@ fun Pokemon.getBucket(): String? {
     }
     return bucket
 }
+
+fun Pokemon.getBucketTranslationKey(): Component =
+    Component.translatable(TimCore.getBucketKeyFromName(this.getBucket()))
 
 fun Pokemon.getSpawnCause(): String? = persistentData.getStringOrNull(TimCore.DataKeys.SPAWNED_VIA)
 

--- a/common/src/main/kotlin/us/timinc/mc/cobblemon/timcore/SpawnBucketExtensions.kt
+++ b/common/src/main/kotlin/us/timinc/mc/cobblemon/timcore/SpawnBucketExtensions.kt
@@ -1,0 +1,8 @@
+package us.timinc.mc.cobblemon.timcore
+
+import com.cobblemon.mod.common.api.spawning.SpawnBucket
+import net.minecraft.network.chat.Component
+import net.minecraft.network.chat.MutableComponent
+
+fun SpawnBucket.getTranslatedName(): MutableComponent? =
+    Component.translatable(TimCore.getBucketKeyFromName(this.name))

--- a/common/src/main/kotlin/us/timinc/mc/cobblemon/timcore/TimCore.kt
+++ b/common/src/main/kotlin/us/timinc/mc/cobblemon/timcore/TimCore.kt
@@ -30,6 +30,13 @@ object TimCore : AbstractMod<TimCore.Config>(MOD_ID, Config::class.java) {
         val reservedPokemonEntitiesAreInvulnerable: Boolean = true
         val requirePartyToFishPokemon: Boolean = false
         val fossilMachineResurrectionTime: Int = 14400
+        val bucketKeys: Map<String, String> = mapOf(
+            "common" to "tim_core.buckets.common",
+            "uncommon" to "tim_core.buckets.uncommon",
+            "rare" to "tim_core.buckets.rare",
+            "ultra-rare" to "tim_core.buckets.ultra_rare"
+        )
+        val unknownBucketKey: String = "tim_core.buckets.unknown"
 
         var _spawnBlacklistMatcher: Set<PokemonMatcher>? = null
         val spawnBlacklistMatcher: Set<PokemonMatcher>
@@ -48,6 +55,8 @@ object TimCore : AbstractMod<TimCore.Config>(MOD_ID, Config::class.java) {
                 }
             }
     }
+
+    fun getBucketKeyFromName(name: String?) = config.bucketKeys[name] ?: config.unknownBucketKey
 
     object Tags {
         @JvmField

--- a/common/src/main/resources/assets/tim_core/lang/en_us.json
+++ b/common/src/main/resources/assets/tim_core/lang/en_us.json
@@ -1,4 +1,9 @@
 {
   "tim_core.feedback.reserved": "That %1$s is reserved for %2$s.",
-  "tim_core.bits.someone_else": "someone else"
+  "tim_core.bits.someone_else": "someone else",
+  "tim_core.buckets.common": "Common",
+  "tim_core.buckets.uncommon": "Uncommon",
+  "tim_core.buckets.rare": "Rare",
+  "tim_core.buckets.ultra_rare": "Ultra Rare",
+  "tim_core.buckets.unknown": "Unknown Bucket"
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ org.gradle.configureondemand=true
 
 modId=tim_core
 modCobblemonVersion=1.7.0
-modMyVersion=1.24.1
+modMyVersion=1.25.0
 modName=Tim Core
 modDescription=What if my Cobblemon mods worked without a bunch of copy/pasting?
 modAuthor=timinc aka Timothy Metcalfe


### PR DESCRIPTION
* Added bucket translated name keys. Options allow you to redefine the keys themselves. Defaults use lang.
* Added getter extensions to Pokemon and SpawnBucket.