### PR TITLE
v1.7.1-1.28.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # Tim Core
 
-v1.7.1-1.27.1
-
-This documentation is out of date, I'm doing rapid development whilst working on 1.7 porting. I'll come back around at some point.
+v1.7.1-1.27
 
 [Modrinth](https://modrinth.com/mod/cobblemon-tim-core)
 
@@ -16,53 +14,57 @@ This documentation is out of date, I'm doing rapid development whilst working on
 
 ## Features
 
-[AbstractMod](https://www.notion.so/AbstractMod-2a557e0d4afd81b5833cff8656bb8e1c?pvs=21)
+[AbstractMod](https://www.notion.so/AbstractMod-2ea57e0d4afd815fa048fe00c8dc9dd7?pvs=21)
 
-[AbstractConfig](https://www.notion.so/AbstractConfig-2a557e0d4afd81cdae45c62a52f1a7f0?pvs=21)
+[AbstractConfig](https://www.notion.so/AbstractConfig-2ea57e0d4afd81309a80d246a2179a5c?pvs=21)
 
-[ConfigBuilder](https://www.notion.so/ConfigBuilder-2a557e0d4afd81b8ab2dd4ba391ad431?pvs=21)
+[ConfigBuilder](https://www.notion.so/ConfigBuilder-2ea57e0d4afd8103848bdaeb1302509b?pvs=21)
 
-[Overridable Options](https://www.notion.so/Overridable-Options-2a557e0d4afd81cbaaf8d30151d06700?pvs=21)
+[Overridable Options](https://www.notion.so/Overridable-Options-2ea57e0d4afd81e1a77fe83578531125?pvs=21)
 
-[AbstractHandler](https://www.notion.so/AbstractHandler-2a557e0d4afd8189b332ed00ebe83159?pvs=21)
+[AbstractHandler](https://www.notion.so/AbstractHandler-2ea57e0d4afd81a38f7ce2cca595006b?pvs=21)
 
-[Debugger](https://www.notion.so/Debugger-2a557e0d4afd81efb2dec1ef30c0e4de?pvs=21)
+[Debugger](https://www.notion.so/Debugger-2ea57e0d4afd810c9ac8c955e93e1f7f?pvs=21)
 
-[PokemonExtensions](https://www.notion.so/PokemonExtensions-2a557e0d4afd81079e56d6e995b058a1?pvs=21)
+[PokemonExtensions](https://www.notion.so/PokemonExtensions-2ea57e0d4afd8109bb41c19872ec50e0?pvs=21)
 
-[Events](https://www.notion.so/Events-2a557e0d4afd81a1a93ee87a380ec095?pvs=21)
+[Events](https://www.notion.so/Events-2ea57e0d4afd8187b7b5e3ab0c40cf3b?pvs=21)
 
-[Custom Pokémon Properties](https://www.notion.so/Custom-Pok-mon-Properties-2a557e0d4afd813db8d6d6a2c07dec01?pvs=21)
+[Custom Pokémon Properties](https://www.notion.so/Custom-Pok-mon-Properties-2ea57e0d4afd81479b28da74a0732d69?pvs=21)
 
-[Holdings](https://www.notion.so/Holdings-2a557e0d4afd813bb8c7fdd8a7ccfc9d?pvs=21)
+[Holdings](https://www.notion.so/Holdings-2ea57e0d4afd8169ada0d23d7aa2e672?pvs=21)
 
-[ExpAll Logic](https://www.notion.so/ExpAll-Logic-2a557e0d4afd8196b11bed924706e279?pvs=21)
+[ExpAll Logic](https://www.notion.so/ExpAll-Logic-2ea57e0d4afd8155b6b1f823c10ea6be?pvs=21)
 
-[Spawning Buckets Attachment](https://www.notion.so/Spawning-Buckets-Attachment-2a557e0d4afd8150a9edeec23411adaa?pvs=21)
+[Spawning Buckets Attachment](https://www.notion.so/Spawning-Buckets-Attachment-2ea57e0d4afd81fdbe23d1c1d96e3e62?pvs=21)
 
-[Spawn Cause Attachment](https://www.notion.so/Spawn-Cause-Attachment-2a557e0d4afd81bab889f531c471d269?pvs=21)
+[Spawn Cause Attachment](https://www.notion.so/Spawn-Cause-Attachment-2ea57e0d4afd8192ac24c7e307c04560?pvs=21)
 
-[`PokemonMatcher`](https://www.notion.so/PokemonMatcher-2a557e0d4afd8110a8f1c726d24524d1?pvs=21)
+[`PokemonMatcher`](https://www.notion.so/PokemonMatcher-2ea57e0d4afd8199a515ca166d64c05f?pvs=21)
 
-[`ResourceReloadListeners`](https://www.notion.so/ResourceReloadListeners-2a557e0d4afd810998ead642257f7a71?pvs=21)
+[`ResourceReloadListeners`](https://www.notion.so/ResourceReloadListeners-2ea57e0d4afd8106b0efe50280f946f6?pvs=21)
 
-[Block & Item Registration](https://www.notion.so/Block-Item-Registration-2a557e0d4afd8119b00ccbefa35401fe?pvs=21)
+[Block & Item Registration](https://www.notion.so/Block-Item-Registration-2ea57e0d4afd81229bf5ce003e5d55ca?pvs=21)
 
-[Commands](https://www.notion.so/Commands-2a557e0d4afd81eaa1b1e115c97e6883?pvs=21)
+[Commands](https://www.notion.so/Commands-2ea57e0d4afd8166afc1e3b035cae092?pvs=21)
 
-[Limited List](https://www.notion.so/Limited-List-2a557e0d4afd81fe9392eac8aa3fc146?pvs=21)
+[Limited List](https://www.notion.so/Limited-List-2ea57e0d4afd81199ed3d7da42b80a57?pvs=21)
 
-[Wild Pokémon Reservation System](https://www.notion.so/Wild-Pok-mon-Reservation-System-2a557e0d4afd8151bdfdc1a6ff783d4b?pvs=21)
+[Wild Pokémon Reservation System](https://www.notion.so/Wild-Pok-mon-Reservation-System-2ea57e0d4afd8102afe0c8e2dafa7542?pvs=21)
 
-[PokemonRepresentation](https://www.notion.so/PokemonRepresentation-2a557e0d4afd81b7ae85e5852e0cb039?pvs=21)
+[PokemonRepresentation](https://www.notion.so/PokemonRepresentation-2ea57e0d4afd8144a3deed7edd918794?pvs=21)
 
-[Base Cobblemon Fixes](https://www.notion.so/Base-Cobblemon-Fixes-2a557e0d4afd816c8944e9a4546ef0bc?pvs=21)
+[Base Cobblemon Fixes](https://www.notion.so/Base-Cobblemon-Fixes-2ea57e0d4afd81ec8506cb06e679a946?pvs=21)
 
-[Prevent Spawns](https://www.notion.so/Prevent-Spawns-2a557e0d4afd81e596b0c354c703d2c7?pvs=21)
+[Prevent Spawns](https://www.notion.so/Prevent-Spawns-2ea57e0d4afd81a4bfe8db4804a35413?pvs=21)
+
+[Spawning Influences](https://www.notion.so/Spawning-Influences-2ea57e0d4afd81a68eb2c7d093e3eb84?pvs=21)
+
+[Custom Property Extractor](https://www.notion.so/Custom-Property-Extractor-2ea57e0d4afd8164a3d1da670965ba3a?pvs=21)
 
 ## Player Help
 
-[Config Options](https://www.notion.so/Config-Options-2a557e0d4afd813ab655e608230b494e?pvs=21)
+[Config Options](https://www.notion.so/Config-Options-2ea57e0d4afd81199028e73d811fef08?pvs=21)
 
 ## Dependencies
 
@@ -70,7 +72,7 @@ This documentation is out of date, I'm doing rapid development whilst working on
 
 ## Known Issues
 
-- v1.6.1-1.18.0 was catching the normal form as the first which the PokemonRepresentation.FromProperties’ aspects satisfied every time. v1.6.1-1.18.1 says forget it, we’re converting it to a proper Pokemon when looking for the form, so long as the species exists.
+- None. Yet. Probably. 👀
 
 ## Roadmap
 

--- a/common/src/main/kotlin/us/timinc/mc/cobblemon/timcore/PokemonMatcher.kt
+++ b/common/src/main/kotlin/us/timinc/mc/cobblemon/timcore/PokemonMatcher.kt
@@ -1,160 +1,41 @@
 package us.timinc.mc.cobblemon.timcore
 
-import com.cobblemon.mod.common.api.pokemon.PokemonProperties
-import com.cobblemon.mod.common.pokemon.IVs
 import com.cobblemon.mod.common.pokemon.Pokemon
-import com.cobblemon.mod.common.util.splitMap
 import com.mojang.serialization.Codec
+import us.timinc.mc.cobblemon.timcore.matcher.MatcherRawData
+import us.timinc.mc.cobblemon.timcore.matcher.piece.Piece
+import java.util.function.Predicate
 
 data class PokemonMatcher(
-    var properties: String = "",
-    var labels: List<String> = emptyList(),
-    var anyLabel: Boolean = false,
-    var persistentData: Map<String, String> = emptyMap(),
-    var anyPersistentData: Boolean = false,
-    var buckets: List<String> = emptyList(),
-    var forms: List<String> = emptyList(),
-    var maxIVs: Int = -1,
-    var matchOne: Boolean = false,
+    val raw: MatcherRawData,
 ) {
     companion object {
+        @Suppress("unused")
         val STRING_CODEC: Codec<PokemonMatcher> = Codec.STRING.xmap(
             { parse(it) },
             { it.asString() }
         )
 
-        fun parse(
-            string: String,
-            delimiter: String = " ",
-            assigner: String = "=",
-            innerDelimiter: String = ",",
-        ): PokemonMatcher {
-            val matcher = PokemonMatcher()
-            matcher.properties = string
-            val keyPairs = string.splitMap(delimiter, assigner)
-            matcher.labels = parseString(keyPairs, listOf("labels"))?.split(innerDelimiter) ?: listOf()
-            matcher.anyLabel = parseBooleanProperty(keyPairs, listOf("any_label")) ?: false
-            matcher.buckets = parseString(keyPairs, listOf("buckets"))?.split(innerDelimiter) ?: listOf()
-            matcher.forms = parseString(keyPairs, listOf("forms"))?.split(innerDelimiter) ?: listOf()
-            matcher.matchOne = parseBooleanProperty(keyPairs, listOf("match_one")) ?: false
-            matcher.persistentData = parseString(keyPairs, listOf("persistent_data"))?.let {
-                it.splitMap(innerDelimiter, assigner).fold(mutableMapOf()) { acc, (k, v) ->
-                    acc[k] = v ?: ""
-                    acc
-                }
-            } ?: emptyMap()
-            matcher.anyPersistentData = parseBooleanProperty(keyPairs, listOf("any_persistent_data")) ?: false
-            matcher.maxIVs = parseInt(keyPairs, listOf("max_ivs")) ?: -1
-            return matcher
+        val pieces: MutableList<Piece<*>> = mutableListOf()
+
+        fun <P : Predicate<Pokemon>> registerPiece(piece: Piece<P>): Piece<P> {
+            pieces.add(piece)
+            return piece
         }
 
-        private fun getMatchedKeyPair(
-            keyPairs: MutableList<Pair<String, String?>>,
-            labels: Iterable<String>,
-        ): Pair<String, String?>? {
-            return keyPairs.findLast { it.first in labels }
-        }
-
-        private fun parseString(keyPairs: MutableList<Pair<String, String?>>, labels: Iterable<String>): String? {
-            val matchingKeyPair = getMatchedKeyPair(keyPairs, labels) ?: return null
-            val value = matchingKeyPair.second
-            return if (value.isNullOrBlank()) {
-                null
-            } else {
-                value
-            }
-        }
-
-        private fun parseInt(keyPairs: MutableList<Pair<String, String?>>, labels: Iterable<String>): Int? {
-            val stringValue = parseString(keyPairs, labels) ?: return null
-            try {
-                return stringValue.toInt()
-            } catch (e: NumberFormatException) {
-                TimCore.debugger.debug("Attempted to use non-int value of $stringValue for maxIVs.")
-                return -1
-            }
-        }
-
-        private fun parseBooleanProperty(
-            keyPairs: MutableList<Pair<String, String?>>,
-            labels: Iterable<String>,
-        ): Boolean? {
-            val matchingKeyPair = getMatchedKeyPair(keyPairs, labels) ?: return null
-            keyPairs.remove(matchingKeyPair)
-            return when (matchingKeyPair.second?.lowercase()) {
-                null -> true
-                "true", "yes" -> true
-                "false", "no" -> false
-                else -> null
-            }
-        }
+        fun parse(string: String): PokemonMatcher = PokemonMatcher(MatcherRawData(string))
     }
 
-    @delegate:Transient
-    private val parsedProps by lazy {
-        properties.takeIf { it.isNotBlank() }?.let(PokemonProperties::parse)
-    }
+    val matchOne: Boolean
+        get() = raw.getBoolean(setOf("match_one")) ?: false
+
+    val conditions: List<Predicate<Pokemon>>
+        get() = pieces.map { it.condition(raw) }
 
     fun matches(pokemon: Pokemon): Boolean {
-        val predicates = buildList<(Pokemon) -> Boolean> {
-            if (parsedProps != null) add { p -> parsedProps!!.matches(p) }
-            if (labels.isNotEmpty()) add(::labelsMatch)
-            if (persistentData.isNotEmpty()) add(::persistentDataMatch)
-            if (buckets.isNotEmpty()) add(::bucketMatch)
-            if (forms.isNotEmpty()) add(::formsMatch)
-            if (maxIVs != -1) add(::maxIVsMatch)
-        }
-
-        if (predicates.isEmpty()) return true
-
-        return if (matchOne) predicates.any { it(pokemon) } else predicates.all { it(pokemon) }
+        if (conditions.isEmpty()) return true
+        return if (matchOne) conditions.any { it.test(pokemon) } else conditions.all { it.test(pokemon) }
     }
 
-    private fun maxIVsMatch(pokemon: Pokemon): Boolean =
-        pokemon.ivs.count { (_, int) -> int == IVs.MAX_VALUE } == maxIVs
-
-    private fun labelsMatch(pokemon: Pokemon): Boolean {
-        val pokeLabels = pokemon.form.labels
-        return if (anyLabel) pokeLabels.any(labels::contains) else pokeLabels.containsAll(labels)
-    }
-
-    private fun persistentDataMatch(pokemon: Pokemon): Boolean {
-        val pd = pokemon.persistentData
-        return if (anyPersistentData) {
-            persistentData.entries.any { (k, v) ->
-                val realKey = pd.allKeys.find { it.equals(k, ignoreCase = true) } ?: return@any false
-                pd.getOrNull(realKey)?.toString() == v
-            }
-        } else {
-            persistentData.entries.all { (k, v) ->
-                val realKey = pd.allKeys.find { it.equals(k, ignoreCase = true) } ?: return@all false
-                pd.getOrNull(realKey)?.toString() == v
-            }
-        }
-    }
-
-    private fun bucketMatch(pokemon: Pokemon): Boolean {
-        val spawnedInBucket = pokemon.getBucket() ?: return false
-        return spawnedInBucket in buckets
-    }
-
-    private fun formsMatch(pokemon: Pokemon): Boolean {
-        return forms.contains(pokemon.form.name)
-    }
-
-    fun asString(separator: String = " "): String {
-        val stringed = mutableListOf<String>()
-
-        if (properties != "") stringed.add(properties)
-        if (labels.isNotEmpty()) stringed.add("labels=${labels.joinToString(",")}")
-        if (anyLabel) stringed.add("any_label")
-        if (buckets.isNotEmpty()) stringed.add("buckets=${buckets.joinToString(",")}")
-        if (forms.isNotEmpty()) stringed.add("forms=${forms.joinToString(",")}")
-        if (matchOne) stringed.add("match_one")
-        if (persistentData.isNotEmpty()) stringed.add("persistent_data=${persistentData.entries.joinToString(",") { (k, v) -> "$k=$v" }}")
-        if (anyPersistentData) stringed.add("any_persistent_data")
-        if (maxIVs != -1) stringed.add("max_ivs=$maxIVs")
-
-        return stringed.joinToString(separator)
-    }
+    fun asString(): String = raw.asString()
 }

--- a/common/src/main/kotlin/us/timinc/mc/cobblemon/timcore/PokemonMatcher.kt
+++ b/common/src/main/kotlin/us/timinc/mc/cobblemon/timcore/PokemonMatcher.kt
@@ -30,11 +30,12 @@ data class PokemonMatcher(
         get() = raw.getBoolean(setOf("match_one")) ?: false
 
     val conditions: List<Predicate<Pokemon>>
-        get() = pieces.map { it.condition(raw) }
+        get() = pieces.mapNotNull { it.condition(raw) }
 
     fun matches(pokemon: Pokemon): Boolean {
-        if (conditions.isEmpty()) return true
-        return if (matchOne) conditions.any { it.test(pokemon) } else conditions.all { it.test(pokemon) }
+        return conditions.takeIf { it.isNotEmpty() }?.let { conditions ->
+            if (matchOne) conditions.any { it.test(pokemon) } else conditions.all { it.test(pokemon) }
+        } ?: true
     }
 
     fun asString(): String = raw.asString()

--- a/common/src/main/kotlin/us/timinc/mc/cobblemon/timcore/PokemonMatcher.kt
+++ b/common/src/main/kotlin/us/timinc/mc/cobblemon/timcore/PokemonMatcher.kt
@@ -19,6 +19,12 @@ data class PokemonMatcher(
         val pieces: MutableList<Piece<*>> = mutableListOf()
 
         fun <P : Predicate<Pokemon>> registerPiece(piece: Piece<P>): Piece<P> {
+            TimCore.debugger.debug("Registering piece with keys ${piece.allKeys.joinToString()}")
+            val overlappingKeys = pieces.flatMap { it.allKeys }.filter(piece.allKeys::contains)
+            if (overlappingKeys.isNotEmpty()) TimCore.debugger.debug(
+                "Registering piece with duplicate key(s) ${overlappingKeys.joinToString()}",
+                true
+            )
             pieces.add(piece)
             return piece
         }

--- a/common/src/main/kotlin/us/timinc/mc/cobblemon/timcore/TimCore.kt
+++ b/common/src/main/kotlin/us/timinc/mc/cobblemon/timcore/TimCore.kt
@@ -2,6 +2,10 @@ package us.timinc.mc.cobblemon.timcore
 
 import com.cobblemon.mod.common.api.Priority
 import com.cobblemon.mod.common.api.events.CobblemonEvents
+import com.cobblemon.mod.common.api.moves.Move
+import com.cobblemon.mod.common.api.pokemon.stats.Stat
+import com.cobblemon.mod.common.api.pokemon.stats.Stats
+import com.cobblemon.mod.common.pokemon.IVs
 import com.cobblemon.mod.common.pokemon.Pokemon
 import com.cobblemon.mod.common.util.getPlayer
 import net.minecraft.core.registries.Registries
@@ -10,9 +14,19 @@ import net.minecraft.network.chat.MutableComponent
 import net.minecraft.tags.TagKey
 import net.minecraft.world.item.Item
 import us.timinc.mc.cobblemon.timcore.data.CustomPropertyExtractorWhitelistManager
-import us.timinc.mc.cobblemon.timcore.handler.*
+import us.timinc.mc.cobblemon.timcore.handler.AttachBucket
+import us.timinc.mc.cobblemon.timcore.handler.AttachSpawnCause
+import us.timinc.mc.cobblemon.timcore.handler.ExpAllHandler
+import us.timinc.mc.cobblemon.timcore.handler.FishingWithoutATeamCanceller
+import us.timinc.mc.cobblemon.timcore.handler.PokeballHitReserved
+import us.timinc.mc.cobblemon.timcore.handler.PreventQuickBallSpam
 import us.timinc.mc.cobblemon.timcore.influence.EntityDidSpawn
 import us.timinc.mc.cobblemon.timcore.influence.PreventSpawnsInfluence
+import us.timinc.mc.cobblemon.timcore.matcher.piece.CompoundTagFloatRangePiece
+import us.timinc.mc.cobblemon.timcore.matcher.piece.CompoundTagPiece
+import us.timinc.mc.cobblemon.timcore.matcher.piece.IntRangePiece
+import us.timinc.mc.cobblemon.timcore.matcher.piece.PropertiesPiece
+import us.timinc.mc.cobblemon.timcore.matcher.piece.StringSetPiece
 import java.util.*
 
 const val MOD_ID = "tim_core"
@@ -95,14 +109,227 @@ object TimCore : AbstractMod<TimCore.Config>(MOD_ID, Config::class.java) {
                 pokemon.getReservedFor()?.let {
                     try {
                         UUID.fromString(it)
-                    } catch (e: Exception) {
+                    } catch (_: Exception) {
                         null
                     }
                 }?.getPlayer() ?: Component.translatable("tim_core.bits.someone_else")
             )
     }
 
+    @Suppress("unused")
+    object PokemonMatcherPieces {
+        val MAX_IVS = PokemonMatcher.registerPiece(
+            IntRangePiece(
+                getter = { it.ivs.count { (_, iv) -> iv == IVs.MAX_VALUE } },
+                minKeys = setOf("max_ivs", "max_ivs_min"),
+                maxKeys = setOf("max_ivs_max"),
+            )
+        )
+        val LEVEL = PokemonMatcher.registerPiece(
+            IntRangePiece(
+                getter = { it.level },
+                minKeys = setOf("level_min"),
+                maxKeys = setOf("level_max"),
+            )
+        )
+        val TOTAL_IVS = PokemonMatcher.registerPiece(
+            IntRangePiece(
+                getter = { it.ivs.total() },
+                minKeys = setOf("total_ivs_min"),
+                maxKeys = setOf("total_ivs_max"),
+            )
+        )
+        val TOTAL_EVS = PokemonMatcher.registerPiece(
+            IntRangePiece(
+                getter = { it.evs.total() },
+                minKeys = setOf("total_evs_min"),
+                maxKeys = setOf("total_evs_max"),
+            )
+        )
+        val FRIENDSHIP = PokemonMatcher.registerPiece(
+            IntRangePiece(
+                getter = { it.friendship },
+                minKeys = setOf("friendship_min"),
+                maxKeys = setOf("friendship_max"),
+            )
+        )
+        val LABELS = PokemonMatcher.registerPiece(
+            StringSetPiece(
+                getter = { it.form.labels },
+                whitelistKeys = setOf("labels"),
+                blacklistKeys = setOf("not_labels"),
+                matchAnyWhitelistKeys = setOf("any_label"),
+            )
+        )
+        val TYPES = PokemonMatcher.registerPiece(
+            StringSetPiece(
+                getter = { it.types.map { type -> type.resourceLocation.toString() }.toSet() },
+                whitelistKeys = setOf("types", "elemental_types"),
+                blacklistKeys = setOf("not_types"),
+                matchAnyWhitelistKeys = setOf("any_type"),
+            )
+        )
+        val PRIMARY_TYPES = PokemonMatcher.registerPiece(
+            StringSetPiece(
+                getter = { it.types.toList().getOrNull(0)?.resourceLocation?.toString()?.let(::setOf) ?: emptySet() },
+                whitelistKeys = setOf("primary_types"),
+                blacklistKeys = setOf("not_primary_types"),
+                matchAnyWhitelistBackup = true
+            )
+        )
+        val SECONDARY_TYPES = PokemonMatcher.registerPiece(
+            StringSetPiece(
+                getter = { it.types.toList().getOrNull(1)?.resourceLocation?.toString()?.let(::setOf) ?: emptySet() },
+                whitelistKeys = setOf("secondary_types"),
+                blacklistKeys = setOf("not_secondary_types"),
+                matchAnyWhitelistBackup = true,
+            )
+        )
+        val EGG_GROUPS = PokemonMatcher.registerPiece(
+            StringSetPiece(
+                getter = { it.form.eggGroups.map { eg -> eg.name }.toSet() },
+                whitelistKeys = setOf("egg_groups"),
+                blacklistKeys = setOf("not_egg_groups"),
+                matchAnyWhitelistBackup = true,
+            )
+        )
+        val ABILITIES = PokemonMatcher.registerPiece(
+            StringSetPiece(
+                getter = { it.ability.template.name.let(::setOf) },
+                whitelistKeys = setOf("abilities"),
+                blacklistKeys = setOf("not_abilities"),
+                matchAnyWhitelistBackup = true,
+            )
+        )
+        val BUCKETS = PokemonMatcher.registerPiece(
+            StringSetPiece(
+                getter = { it.getBucket()?.let(::setOf) ?: emptySet() },
+                whitelistKeys = setOf("buckets"),
+                blacklistKeys = setOf("not_buckets"),
+                matchAnyWhitelistBackup = true,
+            )
+        )
+        val FORMS = PokemonMatcher.registerPiece(
+            StringSetPiece(
+                getter = { it.form.name.let(::setOf) },
+                whitelistKeys = setOf("forms"),
+                blacklistKeys = setOf("not_forms"),
+                matchAnyWhitelistBackup = true,
+            )
+        )
+        val ASPECTS = PokemonMatcher.registerPiece(
+            StringSetPiece(
+                getter = { it.aspects },
+                whitelistKeys = setOf("aspects"),
+                blacklistKeys = setOf("not_aspects"),
+                matchAnyWhitelistKeys = setOf("any_aspects"),
+            )
+        )
+        val MOVES = PokemonMatcher.registerPiece(
+            StringSetPiece(
+                getter = { it.moveSet.getMoves().map(Move::name).toSet() },
+                whitelistKeys = setOf("active_moves"),
+                blacklistKeys = setOf("not_active_moves"),
+                matchAnyWhitelistKeys = setOf("any_active_moves"),
+            )
+        )
+        val MOVE_TYPES = PokemonMatcher.registerPiece(
+            StringSetPiece(
+                getter = { it.moveSet.getMoves().map { move -> move.type.showdownId }.toSet() },
+                whitelistKeys = setOf("active_move_types"),
+                blacklistKeys = setOf("not_active_move_types"),
+                matchAnyWhitelistKeys = setOf("any_active_move_types"),
+            )
+        )
+        val PROPERTIES = PokemonMatcher.registerPiece(PropertiesPiece())
+        val PERSISTENT_DATA = PokemonMatcher.registerPiece(
+            CompoundTagPiece(
+                getter = { it.persistentData },
+                propsKeys = setOf("persistent_data"),
+                matchAnyPropKeys = setOf("any_persistent_data"),
+            )
+        )
+        val PERSISTENT_DATA_RANGE = PokemonMatcher.registerPiece(
+            CompoundTagFloatRangePiece(
+                getter = { it.persistentData },
+                propsKeys = setOf("persistent_data_range"),
+                matchAnyPropKeys = setOf("any_persistent_data_range")
+            )
+        )
+        val DYNAMAX_LEVEL = PokemonMatcher.registerPiece(
+            IntRangePiece(
+                getter = { it.dmaxLevel },
+                minKeys = setOf("dynamax_level_min", "dmax_level_min"),
+                maxKeys = setOf("dynamax_level_max", "dmax_level_max"),
+            )
+        )
+        val TERA_TYPES = PokemonMatcher.registerPiece(
+            StringSetPiece(
+                getter = { setOf(it.teraType.showdownId()) },
+                whitelistKeys = setOf("tera_types"),
+                blacklistKeys = setOf("not_tera_type"),
+                matchAnyWhitelistBackup = true,
+            )
+        )
+        val NICKNAMES = PokemonMatcher.registerPiece(
+            StringSetPiece(
+                getter = { it.nickname?.string?.let(::setOf) ?: emptySet() },
+                whitelistKeys = setOf("nicknames"),
+                blacklistKeys = setOf("not_nicknames"),
+                matchAnyWhitelistBackup = true,
+            )
+        )
+        val STATUSES = PokemonMatcher.registerPiece(
+            StringSetPiece(
+                getter = { it.status?.status?.showdownName?.let(::setOf) ?: emptySet() },
+                whitelistKeys = setOf("statuses"),
+                blacklistKeys = setOf("not_statuses"),
+                matchAnyWhitelistBackup = true,
+            )
+        )
+        val GENDERS = PokemonMatcher.registerPiece(
+            StringSetPiece(
+                getter = { it.gender.name.let(::setOf) },
+                whitelistKeys = setOf("genders"),
+                blacklistKeys = setOf("not_genders"),
+                matchAnyWhitelistBackup = true,
+            )
+        )
+        val NATURES = PokemonMatcher.registerPiece(
+            StringSetPiece(
+                getter = { it.nature.name.toString().let(::setOf) },
+                whitelistKeys = setOf("natures"),
+                blacklistKeys = setOf("not_natures"),
+                matchAnyWhitelistBackup = true,
+            )
+        )
+        val IVS = Stats.BATTLE_ONLY.fold(mutableMapOf<Stat, IntRangePiece>()) { acc, stat ->
+            acc.plus(
+                stat to (PokemonMatcher.registerPiece(
+                    IntRangePiece(
+                        getter = { it.ivs[stat] ?: 0 },
+                        minKeys = setOf("${stat.showdownId}_iv_min", "${stat.identifier.path}_iv_min"),
+                        maxKeys = setOf("${stat.showdownId}_iv_max", "${stat.identifier.path}_iv_max"),
+                    )
+                ) as IntRangePiece)
+            ).toMutableMap()
+        }
+        val EVS = Stats.BATTLE_ONLY.fold(mutableMapOf<Stat, IntRangePiece>()) { acc, stat ->
+            acc.plus(
+                stat to (PokemonMatcher.registerPiece(
+                    IntRangePiece(
+                        getter = { it.evs[stat] ?: 0 },
+                        minKeys = setOf("${stat.showdownId}_ev_min", "${stat.identifier.path}_ev_min"),
+                        maxKeys = setOf("${stat.showdownId}_ev_max", "${stat.identifier.path}_ev_max"),
+                    )
+                ) as IntRangePiece)
+            ).toMutableMap()
+        }
+    }
+
     init {
+        PokemonMatcherPieces
+
         CobblemonEvents.BATTLE_VICTORY.subscribe(Priority.HIGHEST, ExpAllHandler::handle)
         CobblemonEvents.POKEMON_CATCH_RATE.subscribe(Priority.LOWEST, PreventQuickBallSpam::handle)
         CobblemonEvents.THROWN_POKEBALL_HIT.subscribe(Priority.NORMAL, PokeballHitReserved::handle)

--- a/common/src/main/kotlin/us/timinc/mc/cobblemon/timcore/TimCore.kt
+++ b/common/src/main/kotlin/us/timinc/mc/cobblemon/timcore/TimCore.kt
@@ -441,8 +441,8 @@ object TimCore : AbstractMod<TimCore.Config>(MOD_ID, Config::class.java) {
         val EXPERIENCE = PokemonMatcher.registerPiece(
             IntRangePiece(
                 getter = Pokemon::experience,
-                minKeys = setOf("experience_min"),
-                maxKeys = setOf("experience_max"),
+                minKeys = setOf("experience_min", "exp_min"),
+                maxKeys = setOf("experience_max", "exp_max"),
             )
         )
         val CAUGHT_BALLS = PokemonMatcher.registerPiece(

--- a/common/src/main/kotlin/us/timinc/mc/cobblemon/timcore/TimCore.kt
+++ b/common/src/main/kotlin/us/timinc/mc/cobblemon/timcore/TimCore.kt
@@ -13,6 +13,7 @@ import net.minecraft.network.chat.Component
 import net.minecraft.network.chat.MutableComponent
 import net.minecraft.tags.TagKey
 import net.minecraft.world.item.Item
+import us.timinc.mc.cobblemon.timcore.command.PokemonMatcherTestCommand
 import us.timinc.mc.cobblemon.timcore.data.CustomPropertyExtractorWhitelistManager
 import us.timinc.mc.cobblemon.timcore.handler.AttachBucket
 import us.timinc.mc.cobblemon.timcore.handler.AttachSpawnCause
@@ -340,6 +341,7 @@ object TimCore : AbstractMod<TimCore.Config>(MOD_ID, Config::class.java) {
         registerGeneralSpawnerInfluence(PreventSpawnsInfluence())
         registerGeneralSpawnerInfluence(EntityDidSpawn())
         registerReloadListener(CustomPropertyExtractorWhitelistManager)
+        registerCommand(PokemonMatcherTestCommand)
         RELOAD_CONFIG.subscribe {
             config._spawnBlacklistMatcher = null
             config._spawnWhitelistMatcher = null

--- a/common/src/main/kotlin/us/timinc/mc/cobblemon/timcore/TimCore.kt
+++ b/common/src/main/kotlin/us/timinc/mc/cobblemon/timcore/TimCore.kt
@@ -2,9 +2,12 @@ package us.timinc.mc.cobblemon.timcore
 
 import com.cobblemon.mod.common.api.Priority
 import com.cobblemon.mod.common.api.events.CobblemonEvents
+import com.cobblemon.mod.common.api.mark.Mark
 import com.cobblemon.mod.common.api.moves.Move
 import com.cobblemon.mod.common.api.pokemon.stats.Stat
 import com.cobblemon.mod.common.api.pokemon.stats.Stats
+import com.cobblemon.mod.common.api.riding.RidingStyle
+import com.cobblemon.mod.common.api.riding.stats.RidingStat
 import com.cobblemon.mod.common.pokemon.IVs
 import com.cobblemon.mod.common.pokemon.Pokemon
 import com.cobblemon.mod.common.util.getPlayer
@@ -25,6 +28,8 @@ import us.timinc.mc.cobblemon.timcore.influence.EntityDidSpawn
 import us.timinc.mc.cobblemon.timcore.influence.PreventSpawnsInfluence
 import us.timinc.mc.cobblemon.timcore.matcher.piece.CompoundTagFloatRangePiece
 import us.timinc.mc.cobblemon.timcore.matcher.piece.CompoundTagPiece
+import us.timinc.mc.cobblemon.timcore.matcher.piece.DoubleRangePiece
+import us.timinc.mc.cobblemon.timcore.matcher.piece.FloatRangePiece
 import us.timinc.mc.cobblemon.timcore.matcher.piece.IntRangePiece
 import us.timinc.mc.cobblemon.timcore.matcher.piece.PropertiesPiece
 import us.timinc.mc.cobblemon.timcore.matcher.piece.StringSetPiece
@@ -53,6 +58,8 @@ object TimCore : AbstractMod<TimCore.Config>(MOD_ID, Config::class.java) {
             "ultra-rare" to "tim_core.buckets.ultra_rare"
         )
         val unknownBucketKey: String = "tim_core.buckets.unknown"
+        val successKey: String = "tim_core.result.success"
+        val failureKey: String = "tim_core.result.failure"
 
         var _spawnBlacklistMatcher: Set<PokemonMatcher>? = null
         val spawnBlacklistMatcher: Set<PokemonMatcher>
@@ -128,7 +135,7 @@ object TimCore : AbstractMod<TimCore.Config>(MOD_ID, Config::class.java) {
         )
         val LEVEL = PokemonMatcher.registerPiece(
             IntRangePiece(
-                getter = { it.level },
+                getter = Pokemon::level,
                 minKeys = setOf("level_min"),
                 maxKeys = setOf("level_max"),
             )
@@ -149,7 +156,7 @@ object TimCore : AbstractMod<TimCore.Config>(MOD_ID, Config::class.java) {
         )
         val FRIENDSHIP = PokemonMatcher.registerPiece(
             IntRangePiece(
-                getter = { it.friendship },
+                getter = Pokemon::friendship,
                 minKeys = setOf("friendship_min"),
                 maxKeys = setOf("friendship_max"),
             )
@@ -164,7 +171,7 @@ object TimCore : AbstractMod<TimCore.Config>(MOD_ID, Config::class.java) {
         )
         val TYPES = PokemonMatcher.registerPiece(
             StringSetPiece(
-                getter = { it.types.map { type -> type.resourceLocation.toString() }.toSet() },
+                getter = { it.types.map { type -> type.showdownId }.toSet() },
                 whitelistKeys = setOf("types", "elemental_types"),
                 blacklistKeys = setOf("not_types"),
                 matchAnyWhitelistKeys = setOf("any_type"),
@@ -172,7 +179,7 @@ object TimCore : AbstractMod<TimCore.Config>(MOD_ID, Config::class.java) {
         )
         val PRIMARY_TYPES = PokemonMatcher.registerPiece(
             StringSetPiece(
-                getter = { it.types.toList().getOrNull(0)?.resourceLocation?.toString()?.let(::setOf) ?: emptySet() },
+                getter = { it.primaryType.showdownId.let(::setOf) },
                 whitelistKeys = setOf("primary_types"),
                 blacklistKeys = setOf("not_primary_types"),
                 matchAnyWhitelistBackup = true
@@ -180,7 +187,7 @@ object TimCore : AbstractMod<TimCore.Config>(MOD_ID, Config::class.java) {
         )
         val SECONDARY_TYPES = PokemonMatcher.registerPiece(
             StringSetPiece(
-                getter = { it.types.toList().getOrNull(1)?.resourceLocation?.toString()?.let(::setOf) ?: emptySet() },
+                getter = { it.secondaryType?.showdownId?.let(::setOf) ?: emptySet() },
                 whitelistKeys = setOf("secondary_types"),
                 blacklistKeys = setOf("not_secondary_types"),
                 matchAnyWhitelistBackup = true,
@@ -220,7 +227,7 @@ object TimCore : AbstractMod<TimCore.Config>(MOD_ID, Config::class.java) {
         )
         val ASPECTS = PokemonMatcher.registerPiece(
             StringSetPiece(
-                getter = { it.aspects },
+                getter = Pokemon::aspects,
                 whitelistKeys = setOf("aspects"),
                 blacklistKeys = setOf("not_aspects"),
                 matchAnyWhitelistKeys = setOf("any_aspects"),
@@ -242,24 +249,31 @@ object TimCore : AbstractMod<TimCore.Config>(MOD_ID, Config::class.java) {
                 matchAnyWhitelistKeys = setOf("any_active_move_types"),
             )
         )
+        val TOTAL_POWER_POINTS = PokemonMatcher.registerPiece(
+            IntRangePiece(
+                getter = { it.moveSet.getMoves().fold(0) { acc, move -> acc + move.currentPp } },
+                minKeys = setOf("total_pp_min", "pp_min", "power_points_min"),
+                maxKeys = setOf("total_pp_max", "pp_max", "power_points_max"),
+            )
+        )
         val PROPERTIES = PokemonMatcher.registerPiece(PropertiesPiece())
         val PERSISTENT_DATA = PokemonMatcher.registerPiece(
             CompoundTagPiece(
-                getter = { it.persistentData },
+                getter = Pokemon::persistentData,
                 propsKeys = setOf("persistent_data"),
                 matchAnyPropKeys = setOf("any_persistent_data"),
             )
         )
         val PERSISTENT_DATA_RANGE = PokemonMatcher.registerPiece(
             CompoundTagFloatRangePiece(
-                getter = { it.persistentData },
+                getter = Pokemon::persistentData,
                 propsKeys = setOf("persistent_data_range"),
                 matchAnyPropKeys = setOf("any_persistent_data_range")
             )
         )
         val DYNAMAX_LEVEL = PokemonMatcher.registerPiece(
             IntRangePiece(
-                getter = { it.dmaxLevel },
+                getter = Pokemon::dmaxLevel,
                 minKeys = setOf("dynamax_level_min", "dmax_level_min"),
                 maxKeys = setOf("dynamax_level_max", "dmax_level_max"),
             )
@@ -304,7 +318,7 @@ object TimCore : AbstractMod<TimCore.Config>(MOD_ID, Config::class.java) {
                 matchAnyWhitelistBackup = true,
             )
         )
-        val IVS = Stats.BATTLE_ONLY.fold(mutableMapOf<Stat, IntRangePiece>()) { acc, stat ->
+        val IVS = Stats.PERMANENT.fold(mutableMapOf<Stat, IntRangePiece>()) { acc, stat ->
             acc.plus(
                 stat to (PokemonMatcher.registerPiece(
                     IntRangePiece(
@@ -315,7 +329,7 @@ object TimCore : AbstractMod<TimCore.Config>(MOD_ID, Config::class.java) {
                 ) as IntRangePiece)
             ).toMutableMap()
         }
-        val EVS = Stats.BATTLE_ONLY.fold(mutableMapOf<Stat, IntRangePiece>()) { acc, stat ->
+        val EVS = Stats.PERMANENT.fold(mutableMapOf<Stat, IntRangePiece>()) { acc, stat ->
             acc.plus(
                 stat to (PokemonMatcher.registerPiece(
                     IntRangePiece(
@@ -325,6 +339,163 @@ object TimCore : AbstractMod<TimCore.Config>(MOD_ID, Config::class.java) {
                     )
                 ) as IntRangePiece)
             ).toMutableMap()
+        }
+        val STATS = Stats.PERMANENT.map { stat ->
+            PokemonMatcher.registerPiece(
+                IntRangePiece(
+                    getter = { it.getStat(stat) },
+                    minKeys = setOf("${stat.showdownId}_min", "${stat.identifier.path}_min"),
+                    maxKeys = setOf("${stat.showdownId}_max", "${stat.identifier.path}_max"),
+                )
+            )
+        }
+        val MOVE_MIN_ACCURACY = PokemonMatcher.registerPiece(
+            DoubleRangePiece(
+                getter = { it.moveSet.getMoves().minBy(Move::accuracy).accuracy },
+                minKeys = setOf("move_min_accuracy_min", "min_accuracy_min", "move_min_acc_min", "min_acc_min"),
+                maxKeys = setOf("move_min_accuracy_max", "min_accuracy_max", "move_min_acc_max", "min_acc_max"),
+            )
+        )
+        val MOVE_MAX_ACCURACY = PokemonMatcher.registerPiece(
+            DoubleRangePiece(
+                getter = { it.moveSet.getMoves().minBy(Move::accuracy).accuracy },
+                minKeys = setOf("move_max_accuracy_min", "max_accuracy_min", "move_max_acc_min", "max_acc_min"),
+                maxKeys = setOf("move_max_accuracy_max", "max_accuracy_max", "move_max_acc_max", "max_acc_max"),
+            )
+        )
+        val MOVE_MIN_POWER = PokemonMatcher.registerPiece(
+            DoubleRangePiece(
+                getter = { it.moveSet.getMoves().minBy(Move::power).power },
+                minKeys = setOf("move_min_power_min", "min_power_min", "move_min_pow_min", "min_pow_min"),
+                maxKeys = setOf("move_min_power_max", "min_power_max", "move_min_pow_max", "min_pow_max"),
+            )
+        )
+        val MOVE_MAX_POWER = PokemonMatcher.registerPiece(
+            DoubleRangePiece(
+                getter = { it.moveSet.getMoves().minBy(Move::power).power },
+                minKeys = setOf("move_max_power_min", "max_power_min", "move_max_pow_min", "max_pow_min"),
+                maxKeys = setOf("move_max_power_max", "max_power_max", "move_max_pow_max", "max_pow_max"),
+            )
+        )
+        val MARKINGS = PokemonMatcher.registerPiece(
+            StringSetPiece(
+                getter = { it.markings.map(Int::toString).toSet() },
+                whitelistKeys = setOf("markings"),
+                blacklistKeys = setOf("not_markings"),
+                matchAnyWhitelistKeys = setOf("any_markings")
+            )
+        )
+        val MOVE_COUNT = PokemonMatcher.registerPiece(
+            IntRangePiece(
+                getter = { it.moveSet.getMoves().size },
+                minKeys = setOf("move_count_min"),
+                maxKeys = setOf("move_count_max"),
+            )
+        )
+        val CURRENT_FULLNESS = PokemonMatcher.registerPiece(
+            IntRangePiece(
+                getter = Pokemon::currentFullness,
+                minKeys = setOf("current_fullness_min", "cur_fullness_min", "current_full_min", "cur_full_min"),
+                maxKeys = setOf("current_fullness_max", "cur_fullness_max", "current_full_max", "cur_full_max"),
+            )
+        )
+        val MAX_FULLNESS = PokemonMatcher.registerPiece(
+            IntRangePiece(
+                getter = Pokemon::getMaxFullness,
+                minKeys = setOf("max_fullness_min", "max_full_min"),
+                maxKeys = setOf("max_fullness_max", "max_full_max"),
+            )
+        )
+        val CURRENT_HEALTH = PokemonMatcher.registerPiece(
+            IntRangePiece(
+                getter = Pokemon::currentHealth,
+                minKeys = setOf("current_health_min", "cur_health_min", "current_hp_min", "cur_hp_min"),
+                maxKeys = setOf("current_health_max", "cur_health_max", "current_hp_max", "cur_hp_max"),
+            )
+        )
+        val MAX_HEALTH = PokemonMatcher.registerPiece(
+            IntRangePiece(
+                getter = Pokemon::maxHealth,
+                minKeys = setOf("max_health_min", "max_hp_min"),
+                maxKeys = setOf("max_health_max", "max_hp_max"),
+            )
+        )
+        val MARKS = PokemonMatcher.registerPiece(
+            StringSetPiece(
+                getter = {
+                    it.marks.map { mark -> mark.identifier.toString() }.toSet() + it.marks.map(Mark::name).toSet()
+                },
+                whitelistKeys = setOf("marks"),
+                blacklistKeys = setOf("not_marks"),
+                matchAnyWhitelistKeys = setOf("any_marks")
+            )
+        )
+        val ACTIVE_MARKS = PokemonMatcher.registerPiece(
+            StringSetPiece(
+                getter = { it.activeMark?.let { mark -> setOf(mark.name, mark.identifier.toString()) } ?: emptySet() },
+                whitelistKeys = setOf("active_marks"),
+                blacklistKeys = setOf("not_active_marks"),
+                matchAnyWhitelistKeys = setOf("any_active_marks"),
+            )
+        )
+        val EXPERIENCE = PokemonMatcher.registerPiece(
+            IntRangePiece(
+                getter = Pokemon::experience,
+                minKeys = setOf("experience_min"),
+                maxKeys = setOf("experience_max"),
+            )
+        )
+        val CAUGHT_BALLS = PokemonMatcher.registerPiece(
+            StringSetPiece(
+                getter = { it.caughtBall.let { ball -> setOf(ball.name.toString(), ball.name.path) } },
+                whitelistKeys = setOf("caught_balls"),
+                blacklistKeys = setOf("not_caught_balls"),
+                matchAnyWhitelistKeys = setOf("any_caught_balls"),
+            )
+        )
+        val EFFECTIVE_NATURES = PokemonMatcher.registerPiece(
+            StringSetPiece(
+                getter = { it.effectiveNature.let { nature -> setOf(nature.name.toString(), nature.name.path) } },
+                whitelistKeys = setOf("effective_natures"),
+                blacklistKeys = setOf("not_effective_natures"),
+                matchAnyWhitelistKeys = setOf("any_effective_natures"),
+            )
+        )
+        val MINTED_NATURES = PokemonMatcher.registerPiece(
+            StringSetPiece(
+                getter = {
+                    it.mintedNature?.let { nature -> setOf(nature.name.toString(), nature.name.path) } ?: emptySet()
+                },
+                whitelistKeys = setOf("minted_natures"),
+                blacklistKeys = setOf("not_minted_natures"),
+                matchAnyWhitelistKeys = setOf("any_minted_natures"),
+            )
+        )
+        val EXPERIENCE_GROUPS = PokemonMatcher.registerPiece(
+            StringSetPiece(
+                getter = { it.experienceGroup.name.let(::setOf) },
+                whitelistKeys = setOf("experience_groups", "exp_groups"),
+                blacklistKeys = setOf("not_experience_groups", "not_exp_groups"),
+                matchAnyWhitelistKeys = setOf("any_experience_groups", "any_exp_groups"),
+            )
+        )
+        val RIDE_STAMINA = PokemonMatcher.registerPiece(
+            FloatRangePiece(
+                getter = Pokemon::rideStamina,
+                minKeys = setOf("ride_stamina_min", "stamina_min", "stam_min"),
+                maxKeys = setOf("ride_stamina_max", "stamina_max", "stam_max"),
+            )
+        )
+        val RIDE_STATS = RidingStyle.entries.map { style ->
+            RidingStat.entries.map { stat ->
+                PokemonMatcher.registerPiece(
+                    FloatRangePiece(
+                        getter = { it.getRideStat(style, stat) },
+                        minKeys = setOf("${style.name}_${stat.name}_min"),
+                        maxKeys = setOf("${style.name}_${stat.name}_max"),
+                    )
+                )
+            }
         }
     }
 

--- a/common/src/main/kotlin/us/timinc/mc/cobblemon/timcore/TimCore.kt
+++ b/common/src/main/kotlin/us/timinc/mc/cobblemon/timcore/TimCore.kt
@@ -136,8 +136,8 @@ object TimCore : AbstractMod<TimCore.Config>(MOD_ID, Config::class.java) {
         val LEVEL = PokemonMatcher.registerPiece(
             IntRangePiece(
                 getter = Pokemon::level,
-                minKeys = setOf("level_min"),
-                maxKeys = setOf("level_max"),
+                minKeys = setOf("level_min", "lvl_min"),
+                maxKeys = setOf("level_max", "lvl_max"),
             )
         )
         val TOTAL_IVS = PokemonMatcher.registerPiece(
@@ -157,8 +157,8 @@ object TimCore : AbstractMod<TimCore.Config>(MOD_ID, Config::class.java) {
         val FRIENDSHIP = PokemonMatcher.registerPiece(
             IntRangePiece(
                 getter = Pokemon::friendship,
-                minKeys = setOf("friendship_min"),
-                maxKeys = setOf("friendship_max"),
+                minKeys = setOf("friendship_min", "happiness_min"),
+                maxKeys = setOf("friendship_max", "happiness_max"),
             )
         )
         val LABELS = PokemonMatcher.registerPiece(
@@ -252,8 +252,8 @@ object TimCore : AbstractMod<TimCore.Config>(MOD_ID, Config::class.java) {
         val TOTAL_POWER_POINTS = PokemonMatcher.registerPiece(
             IntRangePiece(
                 getter = { it.moveSet.getMoves().fold(0) { acc, move -> acc + move.currentPp } },
-                minKeys = setOf("total_pp_min", "pp_min", "power_points_min"),
-                maxKeys = setOf("total_pp_max", "pp_max", "power_points_max"),
+                minKeys = setOf("total_pp_min", "pp_min", "power_points_min", "sum_pp_min"),
+                maxKeys = setOf("total_pp_max", "pp_max", "power_points_max", "sum_pp_max"),
             )
         )
         val PROPERTIES = PokemonMatcher.registerPiece(PropertiesPiece())
@@ -274,15 +274,15 @@ object TimCore : AbstractMod<TimCore.Config>(MOD_ID, Config::class.java) {
         val DYNAMAX_LEVEL = PokemonMatcher.registerPiece(
             IntRangePiece(
                 getter = Pokemon::dmaxLevel,
-                minKeys = setOf("dynamax_level_min", "dmax_level_min"),
-                maxKeys = setOf("dynamax_level_max", "dmax_level_max"),
+                minKeys = setOf("dynamax_level_min", "dmax_level_min", "dynamax_lvl_min", "dmax_lvl_min"),
+                maxKeys = setOf("dynamax_level_max", "dmax_level_max", "dynamax_lvl_max", "dmax_lvl_max"),
             )
         )
         val TERA_TYPES = PokemonMatcher.registerPiece(
             StringSetPiece(
                 getter = { setOf(it.teraType.showdownId()) },
                 whitelistKeys = setOf("tera_types"),
-                blacklistKeys = setOf("not_tera_type"),
+                blacklistKeys = setOf("not_tera_types"),
                 matchAnyWhitelistBackup = true,
             )
         )
@@ -305,8 +305,8 @@ object TimCore : AbstractMod<TimCore.Config>(MOD_ID, Config::class.java) {
         val GENDERS = PokemonMatcher.registerPiece(
             StringSetPiece(
                 getter = { it.gender.name.let(::setOf) },
-                whitelistKeys = setOf("genders"),
-                blacklistKeys = setOf("not_genders"),
+                whitelistKeys = setOf("genders", "sexes"),
+                blacklistKeys = setOf("not_genders", "not_sexes"),
                 matchAnyWhitelistBackup = true,
             )
         )
@@ -351,28 +351,28 @@ object TimCore : AbstractMod<TimCore.Config>(MOD_ID, Config::class.java) {
         }
         val MOVE_MIN_ACCURACY = PokemonMatcher.registerPiece(
             DoubleRangePiece(
-                getter = { it.moveSet.getMoves().minBy(Move::accuracy).accuracy },
+                getter = { it.moveSet.getMoves().minByOrNull(Move::accuracy)?.accuracy ?: 0.0 },
                 minKeys = setOf("move_min_accuracy_min", "min_accuracy_min", "move_min_acc_min", "min_acc_min"),
                 maxKeys = setOf("move_min_accuracy_max", "min_accuracy_max", "move_min_acc_max", "min_acc_max"),
             )
         )
         val MOVE_MAX_ACCURACY = PokemonMatcher.registerPiece(
             DoubleRangePiece(
-                getter = { it.moveSet.getMoves().minBy(Move::accuracy).accuracy },
+                getter = { it.moveSet.getMoves().maxByOrNull(Move::accuracy)?.accuracy ?: 0.0 },
                 minKeys = setOf("move_max_accuracy_min", "max_accuracy_min", "move_max_acc_min", "max_acc_min"),
                 maxKeys = setOf("move_max_accuracy_max", "max_accuracy_max", "move_max_acc_max", "max_acc_max"),
             )
         )
         val MOVE_MIN_POWER = PokemonMatcher.registerPiece(
             DoubleRangePiece(
-                getter = { it.moveSet.getMoves().minBy(Move::power).power },
+                getter = { it.moveSet.getMoves().minByOrNull(Move::power)?.power ?: 0.0 },
                 minKeys = setOf("move_min_power_min", "min_power_min", "move_min_pow_min", "min_pow_min"),
                 maxKeys = setOf("move_min_power_max", "min_power_max", "move_min_pow_max", "min_pow_max"),
             )
         )
         val MOVE_MAX_POWER = PokemonMatcher.registerPiece(
             DoubleRangePiece(
-                getter = { it.moveSet.getMoves().minBy(Move::power).power },
+                getter = { it.moveSet.getMoves().maxByOrNull(Move::power)?.power ?: 0.0 },
                 minKeys = setOf("move_max_power_min", "max_power_min", "move_max_pow_min", "max_pow_min"),
                 maxKeys = setOf("move_max_power_max", "max_power_max", "move_max_pow_max", "max_pow_max"),
             )
@@ -388,8 +388,8 @@ object TimCore : AbstractMod<TimCore.Config>(MOD_ID, Config::class.java) {
         val MOVE_COUNT = PokemonMatcher.registerPiece(
             IntRangePiece(
                 getter = { it.moveSet.getMoves().size },
-                minKeys = setOf("move_count_min"),
-                maxKeys = setOf("move_count_max"),
+                minKeys = setOf("move_count_min", "moves_min"),
+                maxKeys = setOf("move_count_max", "moves_max"),
             )
         )
         val CURRENT_FULLNESS = PokemonMatcher.registerPiece(
@@ -491,8 +491,8 @@ object TimCore : AbstractMod<TimCore.Config>(MOD_ID, Config::class.java) {
                 PokemonMatcher.registerPiece(
                     FloatRangePiece(
                         getter = { it.getRideStat(style, stat) },
-                        minKeys = setOf("${style.name}_${stat.name}_min"),
-                        maxKeys = setOf("${style.name}_${stat.name}_max"),
+                        minKeys = setOf("${style.name.lowercase()}_${stat.name.lowercase()}_min"),
+                        maxKeys = setOf("${style.name.lowercase()}_${stat.name.lowercase()}_max"),
                     )
                 )
             }

--- a/common/src/main/kotlin/us/timinc/mc/cobblemon/timcore/TimCoreEvents.kt
+++ b/common/src/main/kotlin/us/timinc/mc/cobblemon/timcore/TimCoreEvents.kt
@@ -8,7 +8,11 @@ import com.cobblemon.mod.common.api.reactive.Observable.Companion.filter
 import com.cobblemon.mod.common.api.reactive.Observable.Companion.map
 import com.cobblemon.mod.common.entity.pokemon.PokemonEntity
 import com.cobblemon.mod.common.util.isInBattle
-import us.timinc.mc.cobblemon.timcore.event.*
+import us.timinc.mc.cobblemon.timcore.event.CheckExpAllEvent
+import us.timinc.mc.cobblemon.timcore.event.EntityDidSpawnEvent
+import us.timinc.mc.cobblemon.timcore.event.EntityLoadEvent
+import us.timinc.mc.cobblemon.timcore.event.EntityUnloadEvent
+import us.timinc.mc.cobblemon.timcore.event.PokemonEntityTickedEvent
 
 object TimCoreEvents {
     @JvmField

--- a/common/src/main/kotlin/us/timinc/mc/cobblemon/timcore/command/PokemonMatcherTestCommand.kt
+++ b/common/src/main/kotlin/us/timinc/mc/cobblemon/timcore/command/PokemonMatcherTestCommand.kt
@@ -1,0 +1,52 @@
+package us.timinc.mc.cobblemon.timcore.command
+
+import com.cobblemon.mod.common.api.permission.PermissionLevel
+import com.cobblemon.mod.common.util.party
+import com.mojang.brigadier.Command
+import com.mojang.brigadier.arguments.IntegerArgumentType
+import com.mojang.brigadier.arguments.StringArgumentType
+import com.mojang.brigadier.context.CommandContext
+import net.minecraft.commands.CommandSourceStack
+import net.minecraft.commands.Commands
+import net.minecraft.network.chat.Component
+import us.timinc.mc.cobblemon.timcore.AbstractCommand
+import us.timinc.mc.cobblemon.timcore.PokemonMatcher
+import us.timinc.mc.cobblemon.timcore.TimCore
+
+object PokemonMatcherTestCommand : AbstractCommand<PokemonMatcherTestCommand.Data>(
+    "pokemon_matcher_test",
+    PermissionLevel.ALL_COMMANDS,
+    TimCore,
+    listOf(
+        Commands.argument("slot", IntegerArgumentType.integer(1, 6)),
+        Commands.argument("matcher", StringArgumentType.greedyString()),
+    )
+) {
+    override fun run(
+        commandContext: Data,
+        rawContext: CommandContext<CommandSourceStack>,
+    ): Int {
+        val player = rawContext.source.player ?: return 0
+        val teamMember = player.party().get(commandContext.slot - 1) ?: run {
+            player.sendSystemMessage(Component.translatable("Invalid party slot ${commandContext.slot}."))
+            return 0
+        }
+        if (PokemonMatcher.parse(commandContext.matcher).matches(teamMember)) {
+            player.sendSystemMessage(Component.translatable("tim_core.command.result.pokemon_matcher_test.success"))
+            return Command.SINGLE_SUCCESS
+        }
+        player.sendSystemMessage(Component.translatable("tim_core.command.result.pokemon_matcher_test.failure"))
+        return 0
+    }
+
+    override fun parseContext(ctx: CommandContext<CommandSourceStack>): Data =
+        Data(
+            IntegerArgumentType.getInteger(ctx, "slot"),
+            StringArgumentType.getString(ctx, "matcher"),
+        )
+
+    class Data(
+        val slot: Int,
+        val matcher: String,
+    )
+}

--- a/common/src/main/kotlin/us/timinc/mc/cobblemon/timcore/command/PokemonMatcherTestCommand.kt
+++ b/common/src/main/kotlin/us/timinc/mc/cobblemon/timcore/command/PokemonMatcherTestCommand.kt
@@ -32,10 +32,10 @@ object PokemonMatcherTestCommand : AbstractCommand<PokemonMatcherTestCommand.Dat
             return 0
         }
         if (PokemonMatcher.parse(commandContext.matcher).matches(teamMember)) {
-            player.sendSystemMessage(Component.translatable("tim_core.command.result.pokemon_matcher_test.success"))
+            player.sendSystemMessage(Component.translatable(TimCore.config.successKey))
             return Command.SINGLE_SUCCESS
         }
-        player.sendSystemMessage(Component.translatable("tim_core.command.result.pokemon_matcher_test.failure"))
+        player.sendSystemMessage(Component.translatable(TimCore.config.failureKey))
         return 0
     }
 

--- a/common/src/main/kotlin/us/timinc/mc/cobblemon/timcore/condition/CompoundTagCondition.kt
+++ b/common/src/main/kotlin/us/timinc/mc/cobblemon/timcore/condition/CompoundTagCondition.kt
@@ -1,0 +1,30 @@
+package us.timinc.mc.cobblemon.timcore.condition
+
+import net.minecraft.nbt.CompoundTag
+import us.timinc.mc.cobblemon.timcore.getCompoundOrNull
+import us.timinc.mc.cobblemon.timcore.getOrNull
+import java.util.function.Predicate
+
+class CompoundTagCondition<T>(
+    val props: Map<List<String>, String> = emptyMap(),
+    val matchAnyProp: Boolean = false,
+    val getter: (t: T) -> CompoundTag,
+) : Predicate<T> {
+    override fun test(t: T): Boolean {
+        val compoundTag = getter(t)
+        return if (matchAnyProp) {
+            props.entries.any { (k, v) -> internalTest(compoundTag, k, v) }
+        } else {
+            props.entries.all { (k, v) -> internalTest(compoundTag, k, v) }
+        }
+    }
+
+    private fun internalTest(compoundTag: CompoundTag, keyChain: List<String>, value: String): Boolean {
+        val pointer = if (keyChain.size > 1) keyChain.subList(0, keyChain.size - 1).fold(compoundTag) { acc, key ->
+            val realKey = acc.allKeys.find { it.equals(key, true) } ?: return false
+            acc.getCompoundOrNull(realKey) ?: return false
+        } else compoundTag
+        val target = pointer.getOrNull(keyChain.last()) ?: return false
+        return target.toString() == value
+    }
+}

--- a/common/src/main/kotlin/us/timinc/mc/cobblemon/timcore/condition/CompoundTagFloatRangeCondition.kt
+++ b/common/src/main/kotlin/us/timinc/mc/cobblemon/timcore/condition/CompoundTagFloatRangeCondition.kt
@@ -1,0 +1,30 @@
+package us.timinc.mc.cobblemon.timcore.condition
+
+import net.minecraft.nbt.CompoundTag
+import us.timinc.mc.cobblemon.timcore.getCompoundOrNull
+import us.timinc.mc.cobblemon.timcore.getFloatOrNull
+import java.util.function.Predicate
+
+class CompoundTagFloatRangeCondition<T>(
+    val props: Map<List<String>, Pair<Float, Float>> = emptyMap(),
+    val matchAnyProp: Boolean = false,
+    val getter: (t: T) -> CompoundTag,
+) : Predicate<T> {
+    override fun test(t: T): Boolean {
+        val compoundTag = getter(t)
+        return if (matchAnyProp) {
+            props.entries.any { (k, v) -> internalTest(compoundTag, k, v.first, v.second) }
+        } else {
+            props.entries.all { (k, v) -> internalTest(compoundTag, k, v.first, v.second) }
+        }
+    }
+
+    private fun internalTest(compoundTag: CompoundTag, keyChain: List<String>, min: Float, max: Float): Boolean {
+        val pointer = if (keyChain.size > 1) keyChain.subList(0, keyChain.size - 1).fold(compoundTag) { acc, key ->
+            val realKey = acc.allKeys.find { it.equals(key, true) } ?: return false
+            acc.getCompoundOrNull(realKey) ?: return false
+        } else compoundTag
+        val target = pointer.getFloatOrNull(keyChain.last()) ?: return false
+        return target in min..max
+    }
+}

--- a/common/src/main/kotlin/us/timinc/mc/cobblemon/timcore/condition/PokemonPropertiesCondition.kt
+++ b/common/src/main/kotlin/us/timinc/mc/cobblemon/timcore/condition/PokemonPropertiesCondition.kt
@@ -1,0 +1,15 @@
+package us.timinc.mc.cobblemon.timcore.condition
+
+import com.cobblemon.mod.common.api.pokemon.PokemonProperties
+import com.cobblemon.mod.common.pokemon.Pokemon
+import java.util.function.Predicate
+
+class PokemonPropertiesCondition(
+    val props: String,
+) : Predicate<Pokemon> {
+    private val parsedProps by lazy {
+        props.takeIf { it.isNotBlank() }?.let(PokemonProperties::parse)
+    }
+
+    override fun test(ctx: Pokemon): Boolean = parsedProps?.matches(ctx) ?: true
+}

--- a/common/src/main/kotlin/us/timinc/mc/cobblemon/timcore/condition/RangeCondition.kt
+++ b/common/src/main/kotlin/us/timinc/mc/cobblemon/timcore/condition/RangeCondition.kt
@@ -1,0 +1,11 @@
+package us.timinc.mc.cobblemon.timcore.condition
+
+import java.util.function.Predicate
+
+class RangeCondition<T, V : Comparable<V>>(
+    val min: V,
+    val max: V,
+    val getter: (t: T) -> V,
+) : Predicate<T> {
+    override fun test(t: T): Boolean = getter(t) in min..max
+}

--- a/common/src/main/kotlin/us/timinc/mc/cobblemon/timcore/condition/SetCondition.kt
+++ b/common/src/main/kotlin/us/timinc/mc/cobblemon/timcore/condition/SetCondition.kt
@@ -9,7 +9,11 @@ class SetCondition<T, V>(
     val matchAnyWhitelist: Boolean = false,
 ) : Predicate<T> {
     override fun test(t: T): Boolean = getter(t).let { list ->
-        (if (matchAnyWhitelist) list.any { whitelist.contains(it) } else list.containsAll(whitelist))
-                && !list.any { blacklist.contains(it) }
+        val passedWhitelist = whitelist.isEmpty()
+                || (matchAnyWhitelist && whitelist.any { list.contains(it) })
+                || (!matchAnyWhitelist && whitelist.all { list.contains(it) })
+        val passedBlacklist = blacklist.isEmpty()
+                || blacklist.none { list.contains(it) }
+        return passedWhitelist && passedBlacklist
     }
 }

--- a/common/src/main/kotlin/us/timinc/mc/cobblemon/timcore/condition/SetCondition.kt
+++ b/common/src/main/kotlin/us/timinc/mc/cobblemon/timcore/condition/SetCondition.kt
@@ -1,0 +1,15 @@
+package us.timinc.mc.cobblemon.timcore.condition
+
+import java.util.function.Predicate
+
+class SetCondition<T, V>(
+    val whitelist: Set<V> = emptySet(),
+    val blacklist: Set<V> = emptySet(),
+    val getter: (t: T) -> Set<V>,
+    val matchAnyWhitelist: Boolean = false,
+) : Predicate<T> {
+    override fun test(t: T): Boolean = getter(t).let { list ->
+        (if (matchAnyWhitelist) list.any { whitelist.contains(it) } else list.containsAll(whitelist))
+                && !list.any { blacklist.contains(it) }
+    }
+}

--- a/common/src/main/kotlin/us/timinc/mc/cobblemon/timcore/matcher/MatcherRawData.kt
+++ b/common/src/main/kotlin/us/timinc/mc/cobblemon/timcore/matcher/MatcherRawData.kt
@@ -14,7 +14,10 @@ class MatcherRawData(
         return keyPairs.findLast { it.first in labels }
     }
 
-    fun asString(): String = keyPairs.joinToString(" ") { if (it.second != null) "${it.first}=${it.second}" else it.first }
+    fun asString(ignoreKeys: Set<String> = emptySet()): String =
+        keyPairs
+            .filter { (k) -> !ignoreKeys.contains(k) }
+            .joinToString(" ") { (k, v) -> if (v != null) "$k=$v" else k }
 
     fun updateValue(newValue: String, labels: Set<String>) {
         keyPairs = keyPairs.map { (k, v) -> if (k in labels) k to newValue else k to v }.toMutableList()

--- a/common/src/main/kotlin/us/timinc/mc/cobblemon/timcore/matcher/MatcherRawData.kt
+++ b/common/src/main/kotlin/us/timinc/mc/cobblemon/timcore/matcher/MatcherRawData.kt
@@ -1,0 +1,150 @@
+package us.timinc.mc.cobblemon.timcore.matcher
+
+import com.cobblemon.mod.common.util.splitMap
+import us.timinc.mc.cobblemon.timcore.TimCore
+
+class MatcherRawData(
+    rawString: String,
+) {
+    var keyPairs: MutableList<Pair<String, String?>> = rawString.splitMap(" ", "=")
+
+    private fun getMatchedKeyPair(
+        labels: Set<String>,
+    ): Pair<String, String?>? {
+        return keyPairs.findLast { it.first in labels }
+    }
+
+    fun asString(): String = keyPairs.joinToString(" ") { "${it.first}=${it.second}" }
+
+    fun updateValue(newValue: String, labels: Set<String>) {
+        keyPairs = keyPairs.map { (k, v) -> if (k in labels) k to newValue else k to v }.toMutableList()
+    }
+
+    fun getString(labels: Set<String>): String? {
+        val matchingKeyPair = getMatchedKeyPair(labels) ?: return null
+        val value = matchingKeyPair.second
+        return if (value.isNullOrBlank()) {
+            null
+        } else {
+            value
+        }
+    }
+
+    fun setString(newValue: String, labels: Set<String>) {
+        updateValue(newValue, labels)
+    }
+
+    fun getInt(labels: Set<String>): Int? {
+        val stringValue = getString(labels) ?: return null
+        try {
+            return stringValue.toInt()
+        } catch (_: NumberFormatException) {
+            TimCore.debugger.debug("Attempted to use non-int value of $stringValue.", true)
+            return -1
+        }
+    }
+
+    fun setInt(newValue: Int, labels: Set<String>) {
+        setString(newValue.toString(), labels)
+    }
+
+    fun getBoolean(labels: Set<String>): Boolean? {
+        val matchingKeyPair = getMatchedKeyPair(labels) ?: return null
+        return when (matchingKeyPair.second?.lowercase()) {
+            null -> true
+            "true", "yes" -> true
+            "false", "no" -> false
+            else -> null
+        }
+    }
+
+    fun setBoolean(newValue: Boolean, labels: Set<String>) {
+        setString(if (newValue) "yes" else "no", labels)
+    }
+
+    fun <T> getList(parser: (String) -> T?, labels: Set<String>): List<T>? {
+        val stringValue = getString(labels) ?: return null
+        return stringValue.split(",").mapNotNull { parser(it) }
+    }
+
+    fun setList(newValue: List<*>, labels: Set<String>, separator: String = ",") {
+        setString(newValue.joinToString(separator), labels)
+    }
+
+    @Suppress("unused")
+    fun getStringList(labels: Set<String>) = getList({ it }, labels)
+
+    fun setStringList(newValue: List<String>, labels: Set<String>, separator: String = ",") =
+        setList(newValue, labels, separator)
+
+    fun <T> getSet(parser: (String) -> T?, labels: Set<String>): Set<T>? = getList(parser, labels)?.toSet()
+
+    fun setSet(newValue: Set<*>, labels: Set<String>, separator: String = ",") =
+        setList(newValue.toList(), labels, separator)
+
+    fun getStringSet(labels: Set<String>) = getSet({ it }, labels)
+
+    fun setStringSet(newValue: Set<String>, labels: Set<String>, separator: String = ",") =
+        setSet(newValue, labels, separator)
+
+    fun getStringMap(
+        labels: Set<String>,
+        delimiter: String = ",",
+        assigner: String = "=",
+        keyDelimiter: String = ".",
+    ): Map<List<String>, String>? {
+        val rawMap = getString(labels) ?: return null
+        return rawMap.splitMap(delimiter, assigner)
+            .fold(mutableMapOf()) { acc, (k, v) ->
+                if (v == null) acc else acc.plus(k.split(keyDelimiter) to v).toMutableMap()
+            }
+    }
+
+    fun setStringMap(
+        newValue: Map<List<String>, String>,
+        labels: Set<String>,
+        delimiter: String,
+        assigner: String,
+        keyDelimiter: String,
+    ) {
+        val stringed = newValue.entries.fold(mutableListOf<String>()) { acc, (k, v) ->
+            acc.plus("${k.joinToString(keyDelimiter)}$assigner$v").toMutableList()
+        }.joinToString(delimiter)
+        setString(stringed, labels)
+    }
+
+    fun getFloatPairMap(
+        labels: Set<String>,
+        delimiter: String = ",",
+        assigner: String = "=",
+        keyDelimiter: String = ".",
+        valueDelimiter: String = ":",
+    ): Map<List<String>, Pair<Float, Float>>? {
+        return getStringMap(labels, delimiter, assigner, keyDelimiter)?.entries
+            ?.fold(mutableMapOf()) { acc, (k, v) ->
+                try {
+                    val split = v.split(valueDelimiter)
+                    val min = split[0].toFloat()
+                    val max = split[1].toFloat()
+                    acc.plus(k to (min to max)).toMutableMap()
+                } catch (_: Exception) {
+                    TimCore.debugger.debug("Attempted to use non-int-pair value of $v.", true)
+                    acc
+                }
+            }
+    }
+
+    fun setFloatPairMap(
+        newValue: Map<List<String>, Pair<Float, Float>>,
+        labels: Set<String>,
+        delimiter: String = ",",
+        assigner: String = "=",
+        keyDelimiter: String = ".",
+        valueDelimiter: String = ":",
+    ) {
+        val stringed = newValue.entries.fold(mutableListOf<String>()) { acc, (k, v) ->
+            acc.plus("${k.joinToString(keyDelimiter)}$assigner${v.first}$valueDelimiter${v.second}").toMutableList()
+        }.joinToString(delimiter)
+        setString(stringed, labels)
+    }
+}

--- a/common/src/main/kotlin/us/timinc/mc/cobblemon/timcore/matcher/MatcherRawData.kt
+++ b/common/src/main/kotlin/us/timinc/mc/cobblemon/timcore/matcher/MatcherRawData.kt
@@ -51,6 +51,34 @@ class MatcherRawData(
         setString(newValue.toString(), labels)
     }
 
+    fun getDouble(labels: Set<String>): Double? {
+        val stringValue = getString(labels) ?: return null
+        try {
+            return stringValue.toDouble()
+        } catch (_: NumberFormatException) {
+            TimCore.debugger.debug("Attempted to use non-int value of $stringValue.", true)
+            return -1.0
+        }
+    }
+
+    fun setDouble(newValue: Double, labels: Set<String>) {
+        setString(newValue.toString(), labels)
+    }
+
+    fun getFloat(labels: Set<String>): Float? {
+        val stringValue = getString(labels) ?: return null
+        try {
+            return stringValue.toFloat()
+        } catch (_: NumberFormatException) {
+            TimCore.debugger.debug("Attempted to use non-int value of $stringValue.", true)
+            return -1F
+        }
+    }
+
+    fun setFloat(newValue: Float, labels: Set<String>) {
+        setString(newValue.toString(), labels)
+    }
+
     fun getBoolean(labels: Set<String>): Boolean? {
         val matchingKeyPair = getMatchedKeyPair(labels) ?: return null
         return when (matchingKeyPair.second?.lowercase()) {

--- a/common/src/main/kotlin/us/timinc/mc/cobblemon/timcore/matcher/MatcherRawData.kt
+++ b/common/src/main/kotlin/us/timinc/mc/cobblemon/timcore/matcher/MatcherRawData.kt
@@ -6,12 +6,15 @@ import us.timinc.mc.cobblemon.timcore.TimCore
 class MatcherRawData(
     rawString: String,
 ) {
-    var keyPairs: MutableList<Pair<String, String?>> = rawString.splitMap(" ", "=")
+    var keyPairs: List<Pair<String, String?>> =
+        rawString
+            .splitMap(" ", "=")
+            .map { (k, v) -> k.lowercase() to v }
 
     private fun getMatchedKeyPair(
         labels: Set<String>,
     ): Pair<String, String?>? {
-        return keyPairs.findLast { it.first in labels }
+        return keyPairs.findLast { (k) -> k.lowercase() in labels }
     }
 
     fun asString(ignoreKeys: Set<String> = emptySet()): String =
@@ -20,7 +23,8 @@ class MatcherRawData(
             .joinToString(" ") { (k, v) -> if (v != null) "$k=$v" else k }
 
     fun updateValue(newValue: String, labels: Set<String>) {
-        keyPairs = keyPairs.map { (k, v) -> if (k in labels) k to newValue else k to v }.toMutableList()
+        val cleanedLabels = labels.map(String::lowercase)
+        keyPairs = keyPairs.map { (k, v) -> if (k in cleanedLabels) k to newValue else k to v }.toMutableList()
     }
 
     fun getString(labels: Set<String>): String? {

--- a/common/src/main/kotlin/us/timinc/mc/cobblemon/timcore/matcher/MatcherRawData.kt
+++ b/common/src/main/kotlin/us/timinc/mc/cobblemon/timcore/matcher/MatcherRawData.kt
@@ -14,7 +14,7 @@ class MatcherRawData(
         return keyPairs.findLast { it.first in labels }
     }
 
-    fun asString(): String = keyPairs.joinToString(" ") { "${it.first}=${it.second}" }
+    fun asString(): String = keyPairs.joinToString(" ") { if (it.second != null) "${it.first}=${it.second}" else it.first }
 
     fun updateValue(newValue: String, labels: Set<String>) {
         keyPairs = keyPairs.map { (k, v) -> if (k in labels) k to newValue else k to v }.toMutableList()

--- a/common/src/main/kotlin/us/timinc/mc/cobblemon/timcore/matcher/MatcherRawData.kt
+++ b/common/src/main/kotlin/us/timinc/mc/cobblemon/timcore/matcher/MatcherRawData.kt
@@ -103,9 +103,9 @@ class MatcherRawData(
     fun setStringMap(
         newValue: Map<List<String>, String>,
         labels: Set<String>,
-        delimiter: String,
-        assigner: String,
-        keyDelimiter: String,
+        delimiter: String = ",",
+        assigner: String = "=",
+        keyDelimiter: String = ".",
     ) {
         val stringed = newValue.entries.fold(mutableListOf<String>()) { acc, (k, v) ->
             acc.plus("${k.joinToString(keyDelimiter)}$assigner$v").toMutableList()

--- a/common/src/main/kotlin/us/timinc/mc/cobblemon/timcore/matcher/piece/CompoundTagFloatRangePiece.kt
+++ b/common/src/main/kotlin/us/timinc/mc/cobblemon/timcore/matcher/piece/CompoundTagFloatRangePiece.kt
@@ -1,0 +1,24 @@
+package us.timinc.mc.cobblemon.timcore.matcher.piece
+
+import com.cobblemon.mod.common.pokemon.Pokemon
+import net.minecraft.nbt.CompoundTag
+import us.timinc.mc.cobblemon.timcore.condition.CompoundTagFloatRangeCondition
+import us.timinc.mc.cobblemon.timcore.matcher.MatcherRawData
+
+class CompoundTagFloatRangePiece(
+    val getter: (Pokemon) -> CompoundTag,
+    val propsKeys: Set<String>? = null,
+    val propsBackup: Map<List<String>, Pair<Float, Float>> = emptyMap(),
+    val matchAnyPropKeys: Set<String>? = null,
+    val matchAnyPropBackup: Boolean = false,
+) : Piece<CompoundTagFloatRangeCondition<Pokemon>> {
+    override fun condition(raw: MatcherRawData): CompoundTagFloatRangeCondition<Pokemon> =
+        CompoundTagFloatRangeCondition<Pokemon>(
+            propsKeys?.let(raw::getFloatPairMap) ?: propsBackup,
+            matchAnyPropKeys?.let(raw::getBoolean) ?: matchAnyPropBackup,
+            getter
+        )
+
+    override val allKeys: Set<String>
+        get() = (propsKeys ?: emptySet()) + (matchAnyPropKeys ?: emptySet())
+}

--- a/common/src/main/kotlin/us/timinc/mc/cobblemon/timcore/matcher/piece/CompoundTagFloatRangePiece.kt
+++ b/common/src/main/kotlin/us/timinc/mc/cobblemon/timcore/matcher/piece/CompoundTagFloatRangePiece.kt
@@ -2,22 +2,48 @@ package us.timinc.mc.cobblemon.timcore.matcher.piece
 
 import com.cobblemon.mod.common.pokemon.Pokemon
 import net.minecraft.nbt.CompoundTag
+import us.timinc.mc.cobblemon.timcore.PokemonMatcher
 import us.timinc.mc.cobblemon.timcore.condition.CompoundTagFloatRangeCondition
 import us.timinc.mc.cobblemon.timcore.matcher.MatcherRawData
 
 class CompoundTagFloatRangePiece(
     val getter: (Pokemon) -> CompoundTag,
     val propsKeys: Set<String>? = null,
-    val propsBackup: Map<List<String>, Pair<Float, Float>> = emptyMap(),
     val matchAnyPropKeys: Set<String>? = null,
     val matchAnyPropBackup: Boolean = false,
 ) : Piece<CompoundTagFloatRangeCondition<Pokemon>> {
-    override fun condition(raw: MatcherRawData): CompoundTagFloatRangeCondition<Pokemon> =
-        CompoundTagFloatRangeCondition<Pokemon>(
-            propsKeys?.let(raw::getFloatPairMap) ?: propsBackup,
+    override fun condition(raw: MatcherRawData): CompoundTagFloatRangeCondition<Pokemon>? {
+        val props = propsKeys?.let(raw::getFloatPairMap) ?: return null
+        return CompoundTagFloatRangeCondition(
+            props,
             matchAnyPropKeys?.let(raw::getBoolean) ?: matchAnyPropBackup,
             getter
         )
+    }
+
+    @Suppress("unused")
+    fun apply(
+        matcher: PokemonMatcher,
+        props: Map<List<String>, Pair<Float, Float>>? = null,
+        matchAnyProp: Boolean? = null,
+    ) {
+        props?.let { props ->
+            propsKeys?.let { propsKeys ->
+                matcher.raw.setFloatPairMap(
+                    props,
+                    propsKeys,
+                )
+            }
+        }
+        matchAnyProp?.let { matchAnyProp ->
+            matchAnyPropKeys?.let { matchAnyPropKeys ->
+                matcher.raw.setBoolean(
+                    matchAnyProp,
+                    matchAnyPropKeys,
+                )
+            }
+        }
+    }
 
     override val allKeys: Set<String>
         get() = (propsKeys ?: emptySet()) + (matchAnyPropKeys ?: emptySet())

--- a/common/src/main/kotlin/us/timinc/mc/cobblemon/timcore/matcher/piece/CompoundTagPiece.kt
+++ b/common/src/main/kotlin/us/timinc/mc/cobblemon/timcore/matcher/piece/CompoundTagPiece.kt
@@ -1,0 +1,23 @@
+package us.timinc.mc.cobblemon.timcore.matcher.piece
+
+import com.cobblemon.mod.common.pokemon.Pokemon
+import net.minecraft.nbt.CompoundTag
+import us.timinc.mc.cobblemon.timcore.condition.CompoundTagCondition
+import us.timinc.mc.cobblemon.timcore.matcher.MatcherRawData
+
+class CompoundTagPiece(
+    val getter: (Pokemon) -> CompoundTag,
+    val propsKeys: Set<String>? = null,
+    val propsBackup: Map<List<String>, String> = emptyMap(),
+    val matchAnyPropKeys: Set<String>? = null,
+    val matchAnyPropBackup: Boolean = false,
+) : Piece<CompoundTagCondition<Pokemon>> {
+    override fun condition(raw: MatcherRawData): CompoundTagCondition<Pokemon> = CompoundTagCondition(
+        propsKeys?.let(raw::getStringMap) ?: propsBackup,
+        matchAnyPropKeys?.let(raw::getBoolean) ?: matchAnyPropBackup,
+        getter
+    )
+
+    override val allKeys: Set<String>
+        get() = (propsKeys ?: emptySet()) + (matchAnyPropKeys ?: emptySet())
+}

--- a/common/src/main/kotlin/us/timinc/mc/cobblemon/timcore/matcher/piece/CompoundTagPiece.kt
+++ b/common/src/main/kotlin/us/timinc/mc/cobblemon/timcore/matcher/piece/CompoundTagPiece.kt
@@ -2,21 +2,48 @@ package us.timinc.mc.cobblemon.timcore.matcher.piece
 
 import com.cobblemon.mod.common.pokemon.Pokemon
 import net.minecraft.nbt.CompoundTag
+import us.timinc.mc.cobblemon.timcore.PokemonMatcher
 import us.timinc.mc.cobblemon.timcore.condition.CompoundTagCondition
 import us.timinc.mc.cobblemon.timcore.matcher.MatcherRawData
 
 class CompoundTagPiece(
     val getter: (Pokemon) -> CompoundTag,
     val propsKeys: Set<String>? = null,
-    val propsBackup: Map<List<String>, String> = emptyMap(),
     val matchAnyPropKeys: Set<String>? = null,
     val matchAnyPropBackup: Boolean = false,
 ) : Piece<CompoundTagCondition<Pokemon>> {
-    override fun condition(raw: MatcherRawData): CompoundTagCondition<Pokemon> = CompoundTagCondition(
-        propsKeys?.let(raw::getStringMap) ?: propsBackup,
-        matchAnyPropKeys?.let(raw::getBoolean) ?: matchAnyPropBackup,
-        getter
-    )
+    override fun condition(raw: MatcherRawData): CompoundTagCondition<Pokemon>? {
+        val props = propsKeys?.let(raw::getStringMap) ?: return null
+        return CompoundTagCondition(
+            props,
+            matchAnyPropKeys?.let(raw::getBoolean) ?: matchAnyPropBackup,
+            getter
+        )
+    }
+
+    @Suppress("unused")
+    fun apply(
+        matcher: PokemonMatcher,
+        props: Map<List<String>, String>? = null,
+        matchAnyProp: Boolean? = null,
+    ) {
+        props?.let { props ->
+            propsKeys?.let { propsKeys ->
+                matcher.raw.setStringMap(
+                    props,
+                    propsKeys,
+                )
+            }
+        }
+        matchAnyProp?.let { matchAnyProp ->
+            matchAnyPropKeys?.let { matchAnyPropKeys ->
+                matcher.raw.setBoolean(
+                    matchAnyProp,
+                    matchAnyPropKeys,
+                )
+            }
+        }
+    }
 
     override val allKeys: Set<String>
         get() = (propsKeys ?: emptySet()) + (matchAnyPropKeys ?: emptySet())

--- a/common/src/main/kotlin/us/timinc/mc/cobblemon/timcore/matcher/piece/DoubleRangePiece.kt
+++ b/common/src/main/kotlin/us/timinc/mc/cobblemon/timcore/matcher/piece/DoubleRangePiece.kt
@@ -1,0 +1,35 @@
+package us.timinc.mc.cobblemon.timcore.matcher.piece
+
+import com.cobblemon.mod.common.pokemon.Pokemon
+import us.timinc.mc.cobblemon.timcore.PokemonMatcher
+import us.timinc.mc.cobblemon.timcore.condition.RangeCondition
+import us.timinc.mc.cobblemon.timcore.matcher.MatcherRawData
+
+class DoubleRangePiece(
+    val getter: (Pokemon) -> Double,
+    val minKeys: Set<String>? = null,
+    val maxKeys: Set<String>? = null,
+    val minValueBackup: Double = Double.MIN_VALUE,
+    val maxValueBackup: Double = Double.MAX_VALUE,
+) : Piece<RangeCondition<Pokemon, Double>> {
+    override fun condition(raw: MatcherRawData): RangeCondition<Pokemon, Double>? {
+        val min = minKeys?.let(raw::getDouble)
+        val max = maxKeys?.let(raw::getDouble)
+        if (min == null && max == null) return null
+
+        return RangeCondition(
+            min ?: minValueBackup,
+            max ?: maxValueBackup,
+            getter,
+        )
+    }
+
+    @Suppress("unused")
+    fun apply(matcher: PokemonMatcher, min: Double? = null, max: Double? = null) {
+        min?.let { min -> minKeys?.let { minKeys -> matcher.raw.setDouble(min, minKeys) } }
+        max?.let { max -> maxKeys?.let { maxKeys -> matcher.raw.setDouble(max, maxKeys) } }
+    }
+
+    override val allKeys: Set<String>
+        get() = (minKeys ?: emptySet()) + (maxKeys ?: emptySet())
+}

--- a/common/src/main/kotlin/us/timinc/mc/cobblemon/timcore/matcher/piece/FloatRangePiece.kt
+++ b/common/src/main/kotlin/us/timinc/mc/cobblemon/timcore/matcher/piece/FloatRangePiece.kt
@@ -1,0 +1,35 @@
+package us.timinc.mc.cobblemon.timcore.matcher.piece
+
+import com.cobblemon.mod.common.pokemon.Pokemon
+import us.timinc.mc.cobblemon.timcore.PokemonMatcher
+import us.timinc.mc.cobblemon.timcore.condition.RangeCondition
+import us.timinc.mc.cobblemon.timcore.matcher.MatcherRawData
+
+class FloatRangePiece(
+    val getter: (Pokemon) -> Float,
+    val minKeys: Set<String>? = null,
+    val maxKeys: Set<String>? = null,
+    val minValueBackup: Float = Float.MIN_VALUE,
+    val maxValueBackup: Float = Float.MAX_VALUE,
+) : Piece<RangeCondition<Pokemon, Float>> {
+    override fun condition(raw: MatcherRawData): RangeCondition<Pokemon, Float>? {
+        val min = minKeys?.let(raw::getFloat)
+        val max = maxKeys?.let(raw::getFloat)
+        if (min == null && max == null) return null
+
+        return RangeCondition(
+            min ?: minValueBackup,
+            max ?: maxValueBackup,
+            getter,
+        )
+    }
+
+    @Suppress("unused")
+    fun apply(matcher: PokemonMatcher, min: Float? = null, max: Float? = null) {
+        min?.let { min -> minKeys?.let { minKeys -> matcher.raw.setFloat(min, minKeys) } }
+        max?.let { max -> maxKeys?.let { maxKeys -> matcher.raw.setFloat(max, maxKeys) } }
+    }
+
+    override val allKeys: Set<String>
+        get() = (minKeys ?: emptySet()) + (maxKeys ?: emptySet())
+}

--- a/common/src/main/kotlin/us/timinc/mc/cobblemon/timcore/matcher/piece/IntRangePiece.kt
+++ b/common/src/main/kotlin/us/timinc/mc/cobblemon/timcore/matcher/piece/IntRangePiece.kt
@@ -12,12 +12,19 @@ class IntRangePiece(
     val minValueBackup: Int = Int.MIN_VALUE,
     val maxValueBackup: Int = Int.MAX_VALUE,
 ) : Piece<RangeCondition<Pokemon, Int>> {
-    override fun condition(raw: MatcherRawData): RangeCondition<Pokemon, Int> = RangeCondition(
-        minKeys?.let(raw::getInt) ?: minValueBackup,
-        maxKeys?.let(raw::getInt) ?: maxValueBackup,
-        getter,
-    )
+    override fun condition(raw: MatcherRawData): RangeCondition<Pokemon, Int>? {
+        val min = minKeys?.let(raw::getInt)
+        val max = maxKeys?.let(raw::getInt)
+        if (min == null && max == null) return null
 
+        return RangeCondition(
+            min ?: minValueBackup,
+            max ?: maxValueBackup,
+            getter,
+        )
+    }
+
+    @Suppress("unused")
     fun apply(matcher: PokemonMatcher, min: Int? = null, max: Int? = null) {
         min?.let { min -> minKeys?.let { minKeys -> matcher.raw.setInt(min, minKeys) } }
         max?.let { max -> maxKeys?.let { maxKeys -> matcher.raw.setInt(max, maxKeys) } }

--- a/common/src/main/kotlin/us/timinc/mc/cobblemon/timcore/matcher/piece/IntRangePiece.kt
+++ b/common/src/main/kotlin/us/timinc/mc/cobblemon/timcore/matcher/piece/IntRangePiece.kt
@@ -1,0 +1,28 @@
+package us.timinc.mc.cobblemon.timcore.matcher.piece
+
+import com.cobblemon.mod.common.pokemon.Pokemon
+import us.timinc.mc.cobblemon.timcore.PokemonMatcher
+import us.timinc.mc.cobblemon.timcore.condition.RangeCondition
+import us.timinc.mc.cobblemon.timcore.matcher.MatcherRawData
+
+class IntRangePiece(
+    val getter: (pokemon: Pokemon) -> Int,
+    val minKeys: Set<String>? = null,
+    val maxKeys: Set<String>? = null,
+    val minValueBackup: Int = Int.MIN_VALUE,
+    val maxValueBackup: Int = Int.MAX_VALUE,
+) : Piece<RangeCondition<Pokemon, Int>> {
+    override fun condition(raw: MatcherRawData): RangeCondition<Pokemon, Int> = RangeCondition(
+        minKeys?.let(raw::getInt) ?: minValueBackup,
+        maxKeys?.let(raw::getInt) ?: maxValueBackup,
+        getter,
+    )
+
+    fun apply(matcher: PokemonMatcher, min: Int? = null, max: Int? = null) {
+        min?.let { min -> minKeys?.let { minKeys -> matcher.raw.setInt(min, minKeys) } }
+        max?.let { max -> maxKeys?.let { maxKeys -> matcher.raw.setInt(max, maxKeys) } }
+    }
+
+    override val allKeys: Set<String>
+        get() = (minKeys ?: emptySet()) + (maxKeys ?: emptySet())
+}

--- a/common/src/main/kotlin/us/timinc/mc/cobblemon/timcore/matcher/piece/Piece.kt
+++ b/common/src/main/kotlin/us/timinc/mc/cobblemon/timcore/matcher/piece/Piece.kt
@@ -5,6 +5,6 @@ import us.timinc.mc.cobblemon.timcore.matcher.MatcherRawData
 import java.util.function.Predicate
 
 interface Piece<P : Predicate<Pokemon>> {
-    fun condition(raw: MatcherRawData): P
+    fun condition(raw: MatcherRawData): P?
     val allKeys: Set<String>
 }

--- a/common/src/main/kotlin/us/timinc/mc/cobblemon/timcore/matcher/piece/Piece.kt
+++ b/common/src/main/kotlin/us/timinc/mc/cobblemon/timcore/matcher/piece/Piece.kt
@@ -1,0 +1,10 @@
+package us.timinc.mc.cobblemon.timcore.matcher.piece
+
+import com.cobblemon.mod.common.pokemon.Pokemon
+import us.timinc.mc.cobblemon.timcore.matcher.MatcherRawData
+import java.util.function.Predicate
+
+interface Piece<P : Predicate<Pokemon>> {
+    fun condition(raw: MatcherRawData): P
+    val allKeys: Set<String>
+}

--- a/common/src/main/kotlin/us/timinc/mc/cobblemon/timcore/matcher/piece/PropertiesPiece.kt
+++ b/common/src/main/kotlin/us/timinc/mc/cobblemon/timcore/matcher/piece/PropertiesPiece.kt
@@ -1,0 +1,12 @@
+package us.timinc.mc.cobblemon.timcore.matcher.piece
+
+import us.timinc.mc.cobblemon.timcore.condition.PokemonPropertiesCondition
+import us.timinc.mc.cobblemon.timcore.matcher.MatcherRawData
+
+class PropertiesPiece() : Piece<PokemonPropertiesCondition> {
+    override fun condition(raw: MatcherRawData): PokemonPropertiesCondition =
+        PokemonPropertiesCondition(raw.asString())
+
+    override val allKeys: Set<String>
+        get() = emptySet()
+}

--- a/common/src/main/kotlin/us/timinc/mc/cobblemon/timcore/matcher/piece/PropertiesPiece.kt
+++ b/common/src/main/kotlin/us/timinc/mc/cobblemon/timcore/matcher/piece/PropertiesPiece.kt
@@ -1,11 +1,12 @@
 package us.timinc.mc.cobblemon.timcore.matcher.piece
 
+import us.timinc.mc.cobblemon.timcore.PokemonMatcher
 import us.timinc.mc.cobblemon.timcore.condition.PokemonPropertiesCondition
 import us.timinc.mc.cobblemon.timcore.matcher.MatcherRawData
 
 class PropertiesPiece() : Piece<PokemonPropertiesCondition> {
     override fun condition(raw: MatcherRawData): PokemonPropertiesCondition =
-        PokemonPropertiesCondition(raw.asString())
+        PokemonPropertiesCondition(raw.asString(PokemonMatcher.pieces.flatMap { it.allKeys }.toSet()))
 
     override val allKeys: Set<String>
         get() = emptySet()

--- a/common/src/main/kotlin/us/timinc/mc/cobblemon/timcore/matcher/piece/StringSetPiece.kt
+++ b/common/src/main/kotlin/us/timinc/mc/cobblemon/timcore/matcher/piece/StringSetPiece.kt
@@ -14,13 +14,20 @@ class StringSetPiece(
     val matchAnyWhitelistKeys: Set<String>? = null,
     val matchAnyWhitelistBackup: Boolean = false,
 ) : Piece<SetCondition<Pokemon, String>> {
-    override fun condition(raw: MatcherRawData): SetCondition<Pokemon, String> = SetCondition(
-        whitelistKeys?.let(raw::getStringSet) ?: whitelistBackup,
-        blacklistKeys?.let(raw::getStringSet) ?: blacklistBackup,
-        getter,
-        matchAnyWhitelistKeys?.let(raw::getBoolean) ?: matchAnyWhitelistBackup
-    )
+    override fun condition(raw: MatcherRawData): SetCondition<Pokemon, String>? {
+        val whitelist = whitelistKeys?.let(raw::getStringSet)
+        val blacklist = blacklistKeys?.let(raw::getStringSet)
+        if (whitelist == null && blacklist == null) return null
 
+        return SetCondition(
+            whitelist ?: whitelistBackup,
+            blacklist ?: blacklistBackup,
+            getter,
+            matchAnyWhitelistKeys?.let(raw::getBoolean) ?: matchAnyWhitelistBackup
+        )
+    }
+
+    @Suppress("unused")
     fun apply(
         matcher: PokemonMatcher,
         whitelist: Set<String>? = null,

--- a/common/src/main/kotlin/us/timinc/mc/cobblemon/timcore/matcher/piece/StringSetPiece.kt
+++ b/common/src/main/kotlin/us/timinc/mc/cobblemon/timcore/matcher/piece/StringSetPiece.kt
@@ -1,0 +1,56 @@
+package us.timinc.mc.cobblemon.timcore.matcher.piece
+
+import com.cobblemon.mod.common.pokemon.Pokemon
+import us.timinc.mc.cobblemon.timcore.PokemonMatcher
+import us.timinc.mc.cobblemon.timcore.condition.SetCondition
+import us.timinc.mc.cobblemon.timcore.matcher.MatcherRawData
+
+class StringSetPiece(
+    val getter: (pokemon: Pokemon) -> Set<String>,
+    val whitelistKeys: Set<String>? = null,
+    val whitelistBackup: Set<String> = emptySet(),
+    val blacklistKeys: Set<String>? = null,
+    val blacklistBackup: Set<String> = emptySet(),
+    val matchAnyWhitelistKeys: Set<String>? = null,
+    val matchAnyWhitelistBackup: Boolean = false,
+) : Piece<SetCondition<Pokemon, String>> {
+    override fun condition(raw: MatcherRawData): SetCondition<Pokemon, String> = SetCondition(
+        whitelistKeys?.let(raw::getStringSet) ?: whitelistBackup,
+        blacklistKeys?.let(raw::getStringSet) ?: blacklistBackup,
+        getter,
+        matchAnyWhitelistKeys?.let(raw::getBoolean) ?: matchAnyWhitelistBackup
+    )
+
+    fun apply(
+        matcher: PokemonMatcher,
+        whitelist: Set<String>? = null,
+        blacklist: Set<String>? = null,
+        matchAnyWhitelist: Boolean? = null,
+    ) {
+        whitelist?.let { whitelist ->
+            whitelistKeys?.let { whitelistKeys ->
+                matcher.raw.setStringSet(
+                    whitelist,
+                    whitelistKeys
+                )
+            }
+        }
+        blacklist?.let { blacklist ->
+            blacklistKeys?.let { blacklistKeys ->
+                matcher.raw.setStringSet(
+                    blacklist,
+                    blacklistKeys
+                )
+            }
+        }
+        matchAnyWhitelist?.let { matchAnyWhitelist ->
+            matchAnyWhitelistKeys?.let { matchAnyWhitelistKeys ->
+                matcher.raw.setBoolean(matchAnyWhitelist, matchAnyWhitelistKeys)
+            }
+        }
+    }
+
+    override val allKeys: Set<String>
+        get() = (whitelistKeys ?: emptySet()) + (blacklistKeys ?: emptySet()) + (matchAnyWhitelistKeys
+            ?: emptySet())
+}

--- a/common/src/main/resources/assets/tim_core/lang/en_us.json
+++ b/common/src/main/resources/assets/tim_core/lang/en_us.json
@@ -5,5 +5,7 @@
   "tim_core.buckets.uncommon": "Uncommon",
   "tim_core.buckets.rare": "Rare",
   "tim_core.buckets.ultra_rare": "Ultra Rare",
-  "tim_core.buckets.unknown": "Unknown Bucket"
+  "tim_core.buckets.unknown": "Unknown Bucket",
+  "tim_core.result.success": "Success",
+  "tim_core.result.failure": "Failure"
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ org.gradle.configureondemand=true
 
 modId=tim_core
 modCobblemonVersion=1.7.1
-modMyVersion=1.27.1
+modMyVersion=1.28.0
 modName=Tim Core
 modDescription=What if my Cobblemon mods worked without a bunch of copy/pasting?
 modAuthor=timinc aka Timothy Metcalfe


### PR DESCRIPTION
* Expanded upon the PokemonMatcher.
* Factored out the PokemonMatcher's static references to conditions and their keys into Pieces. You can make some of these yourself in your own mod and add them directly to PokemonMatcher, should you desire to.
* Added a ton of new Pieces to the PokemonMatcher. Too many to list. Ok, I'll do it: Properties, Max IVs, Level, Total IVs, Total EVs, Friendship, Labels, Types, Primary Types, Secondary Types, Egg Groups, Abilities, Buckets, Forms, Aspects, Moves, Move Types, Total Power Points, Persistent Data, Persistent Data Range, Dynamax Level, Tera Types, Nicknames, Statuses, Genders, Natures, IVs, EVs, Stats, Move Min Accuracy, Move Max Accuracy, Move Min Power, Move Max Power, Markings, Move Count, Current Fullness, Max Fullness, Current Health, Max Health, Marks, Active Marks, Experience, Caught Balls, Effective Natures, Minted Natures, Experience Groups, Ride Stamina, Ride Stats.
* Also added a pokemon_matcher_test command to test a PokemonMatcher string against a Pokemon in a given slot on your party. Neat.