### PR TITLE
v1.7.1-1.28.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Tim Core
 
-v1.7.1-1.27
+v1.7.1-1.28
 
 [Modrinth](https://modrinth.com/mod/cobblemon-tim-core)
 
@@ -72,7 +72,7 @@ v1.7.1-1.27
 
 ## Known Issues
 
-- None. Yet. Probably. 👀
+- ≤v1.7.1-1.28.0 I forgot to provide a backwards-compatible version of the new, simpler parse method. v1.7.1-1.28.1 I re-added the old version that just calls the new version so nothing breaks with a deprecation warning.
 
 ## Roadmap
 

--- a/common/src/main/kotlin/us/timinc/mc/cobblemon/timcore/PokemonMatcher.kt
+++ b/common/src/main/kotlin/us/timinc/mc/cobblemon/timcore/PokemonMatcher.kt
@@ -30,6 +30,20 @@ data class PokemonMatcher(
         }
 
         fun parse(string: String): PokemonMatcher = PokemonMatcher(MatcherRawData(string))
+
+        /**
+         * Legacy function, do not remove until everybody else has been recompiled against the newer version above.
+         * Alternatively, we could actually use the unused values here, but I don't think that's necessary as we
+         * handle the separators ourselves pretty well.
+         */
+        @Suppress("unused")
+        @Deprecated("Use the single-input parse w/o separator params.")
+        fun parse(
+            string: String,
+            delimiter: String = " ",
+            assigner: String = "=",
+            innerDelimiter: String = ",",
+        ): PokemonMatcher = parse(string)
     }
 
     val matchOne: Boolean

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ org.gradle.configureondemand=true
 
 modId=tim_core
 modCobblemonVersion=1.7.1
-modMyVersion=1.28.0
+modMyVersion=1.28.1
 modName=Tim Core
 modDescription=What if my Cobblemon mods worked without a bunch of copy/pasting?
 modAuthor=timinc aka Timothy Metcalfe


### PR DESCRIPTION
* Fixed an issue with removing a deprecated version of PokemonMatcher's parse method. By adding it back. For now.